### PR TITLE
Using '-' as file name forces gist to read from stdin. 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,10 +26,13 @@ Old school:
 Use
 ---
 
-    gist < file.txt
-    echo secret | gist --private # or -p
-    echo "puts :hi" | gist -t rb
-    gist script.py
+    $ gist < file.txt
+    $ echo secret | gist --private # or -p
+    $ echo "puts :hi" | gist -t rb
+    $ gist script.py
+    $ gist -
+    the quick brown fox jumps over the lazy dog
+    ^D
 
 
 Authentication

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -80,8 +80,10 @@ module Gist
           exit
         end
 
+        if args[0] == '-'
+          input = $stdin.read
         # Check if arg is a file. If so, grab the content.
-        if File.exists?(file = args[0])
+        elsif File.exists?(file = args[0])
           input = File.read(file)
           gist_filename = file
           gist_extension = File.extname(file) if file.include?('.')

--- a/man/gist.1.ron
+++ b/man/gist.1.ron
@@ -3,7 +3,7 @@ gist(1) -- gist on the command line
 
 ## SYNOPSIS
 
-`gist` [`-p`] [`-t extension`] <FILE>
+`gist` [`-p`] [`-t extension`] <FILE|->
 
 ## DESCRIPTION
 
@@ -12,7 +12,8 @@ line. There are two primary methods of creating gists.
 
 If standard input is supplied, it will be used as the content of the
 new gist. If <FILE> is provided, the content of that file will be used
-to create the gist.
+to create the gist. If <FILE> is '-' then gist will wait for content
+from standard input.
 
 Once your gist is successfully created, the URL will be copied to your
 clipboard. If you are on OS X, `gist` will open the gist in your
@@ -93,6 +94,9 @@ The following environment variables affect the execution of `gist`:
     $ echo secret | gist --private
     $ echo "puts :hi" | gist -t rb
     $ gist script.py
+    $ gist -
+    the quick brown fox jumps over the lazy dog
+    ^D
 
 ## BUGS
 


### PR DESCRIPTION
Hey,

Quite often I'm getting annoyed that gist barks when I'm trying to use '-' instead of a file name. I'm used to other tools accepting this as a switch telling them to read data from stdin. So gist is somewhat non-intuitive in this aspect. This trivial patch changes gist to treat '-' file name in a special way. What do you think about this?
