### PR TITLE
Support for multi-file gists

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,7 @@ Use
     $ echo secret | gist --private # or -p
     $ echo "puts :hi" | gist -t rb
     $ gist script.py
+    $ gist script.js notes.txt
     $ gist -
     the quick brown fox jumps over the lazy dog
     ^D


### PR DESCRIPTION
This patch adds support for multi-file gists. Example
    $ gist file1.txt file2.txt
Or, in a situation where I want to show someone my merge conflicts: 
    $ git ls-files --unmerged | cut -f 2 | uniq | xargs gist

See also defunkt/gist#4.
