### PR TITLE
Fixed minor documentation error in readme.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ RubyGems:
 
 Old school:
 
-    curl -s http://github.com/defunkt/gist/raw/master/gist > gist &&
+    curl -s https://github.com/defunkt/gist/raw/master/gist > gist &&
     chmod 755 gist &&
     mv gist /usr/local/bin/gist
 


### PR DESCRIPTION
The current "Old School" method to install gist calls an http version of the raw file on github. The content returned is an http 304 response (see below) to the https location instead of the expected ruby executable "gist" file.  Updated the link to https and tested it in the cli. 

```
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/0.7.67</center>
</body>
</html>
```
