### PR TITLE
Opening gists in a browser on Linux

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -151,6 +151,8 @@ module Gist
   def browse(url)
     if RUBY_PLATFORM =~ /darwin/
       `open #{url}`
+    elsif RUBY_PLATFORM =~ /linux/
+       `#{ENV['BROWSER']} #{url}`
     elsif ENV['OS'] == 'Windows_NT' or
       RUBY_PLATFORM =~ /djgpp|(cyg|ms|bcc)win|mingw|wince/i
       `start "" "#{url}"`


### PR DESCRIPTION
This adds opening of the gist in the browser window in Linux using the BROWSER variable, defined in some Linux distributions.
