### PR TITLE
Omit \n when piping output

### DIFF
--- a/gist
+++ b/gist
@@ -176,7 +176,7 @@ module Gist
       url = write(files, private_gist)
       browse(url) if browse_enabled
       copy(url) if copy
-      puts url
+      $stdout.tty? ? puts(url) : print(url)
     rescue => e
       warn e
       puts opts


### PR DESCRIPTION
Rarely would you want \n in the piped output, such as when feeding the resulting URL to a command that would process it.
