### PR TITLE
Omit \n in piped output and make copy to clipboard optional

### DIFF
--- a/gist
+++ b/gist
@@ -266,12 +266,20 @@ private
   def defaults
     extension = config("gist.extension")
     extension = nil if extension && extension.empty?
+    
+    copy = config("gist.copy")
+    if copy.nil?
+      copy = true
+    else
+      # match optparse boolean true states
+      copy = copy =~ /^(true)|(on)|(\+)/
+    end
 
     return {
       "private"   => config("gist.private"),
       "browse"    => config("gist.browse"),
       "extension" => extension,
-      "copy"      => config("gist.copy"),
+      "copy"      => copy,
     }
   end
 


### PR DESCRIPTION
Ok, so I guess pull requests can't include a single commit or a subrange of commits.

For optional copy: I frequently pipe from pbpaste and don't want the clipboard contents wiped out. Passing -c to gist is fine for me, and the change also introduces GIST_COPY env var.

For omitting \n: Rarely would you want \n in the piped output, such as when piping the URL to some program that will process it.
