### PR TITLE
Use File.basename(file) for filename that is sent to API

### DIFF
--- a/gist
+++ b/gist
@@ -163,7 +163,7 @@ module Gist
 
           files.push({
             :input     => File.read(file),
-            :filename  => file,
+            :filename  => File.basename(file),
             :extension => (File.extname(file) if file.include?('.'))
           })
         end


### PR DESCRIPTION
I tried to make a gist out of my spec_helper:

```
$ gist spec/spec_helper.rb
Creating gist failed: 200 OK
```

No gist created. I found out that filename was set to 'spec/spec_helper.rb' which isn't accepted by API.
Using File.basename(file) solves the issue.
