### PR TITLE
fix the URL in the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ $ gist -h
 Old school:
 
 ```bash
-$ curl -s https://github.com/defunkt/gist/raw/master/gist > gist &&
+$ curl -s https://raw.github.com/defunkt/gist/master/gist > gist &&
 $ chmod 755 gist &&
 $ mv gist /usr/local/bin/gist
 ```


### PR DESCRIPTION
The curl command line the README currently has just results in the
HTML of a redirect page.
