### PR TITLE
Use the github api and allow gist url override.

### DIFF
--- a/gist
+++ b/gist
@@ -85,15 +85,14 @@ end
 require 'open-uri'
 require 'net/https'
 require 'optparse'
+require 'rubygems'
+require 'json'
 
 require 'gist/manpage' unless defined?(Gist::Manpage)
 require 'gist/version' unless defined?(Gist::Version)
 
 module Gist
   extend self
-
-  GIST_URL   = 'https://gist.github.com/%s.txt'
-  CREATE_URL = 'https://gist.github.com/gists'
 
   if ENV['HTTPS_PROXY']
     PROXY = URI(ENV['HTTPS_PROXY'])
@@ -104,17 +103,49 @@ module Gist
   end
   PROXY_HOST = PROXY ? PROXY.host : nil
   PROXY_PORT = PROXY ? PROXY.port : nil
+  
+  @url
+  
+  def url
+    @url = @url || defaults["url"] || 'https://api.github.com'
+  end
+  
+  def url=(u)
+    @url = u
+  end
+  
+  def fix_url
+    if /gists$/.match(url)
+      url
+    elsif /\/$/.match(url)
+      url + 'gists'
+    else
+      url + '/gists'
+    end
+  end
+  
+  def create_url
+    fix_url
+  end
+  
+  def get_url
+    fix_url + '/%s'
+  end
 
   def execute(*args)
     private_gist = defaults["private"]
     gist_filename = nil
     gist_extension = defaults["extension"]
     browse_enabled = defaults["browse"]
-    copy = defaults["copy"]
+    description = nil
 
     opts = OptionParser.new do |opts|
       opts.banner = "Usage: gist [options] [filename or stdin] [filename] ...\n" +
         "Filename '-' forces gist to read from stdin."
+        
+      opts.on('-u', '--url', 'Gist URL') do |u|
+        url = u
+      end
 
       opts.on('-p', '--[no-]private', 'Make the gist private') do |priv|
         private_gist = priv
@@ -123,6 +154,10 @@ module Gist
       t_desc = 'Set syntax highlighting of the Gist by file extension'
       opts.on('-t', '--type [EXTENSION]', t_desc) do |extension|
         gist_extension = '.' + extension
+      end
+
+      opts.on('-d','--description DESCRIPTION', 'Set description of the new gist') do |d|
+        description = d
       end
 
       opts.on('-o','--[no-]open', 'Open gist in browser') do |o|
@@ -142,15 +177,12 @@ module Gist
         puts opts
         exit
       end
-
-      opts.on('-c', '--[no-]copy', 'Copy gist URL to clipboard automatically') do |c|
-        copy = c
-      end
     end
 
-    opts.parse!(args)
-
     begin
+
+      opts.parse!(args)
+
       if $stdin.tty? && args[0] != '-'
 
         if args.empty?
@@ -163,7 +195,7 @@ module Gist
 
           files.push({
             :input     => File.read(file),
-            :filename  => File.basename(file),
+            :filename  => file,
             :extension => (File.extname(file) if file.include?('.'))
           })
         end
@@ -173,18 +205,17 @@ module Gist
         files = [{:input => input, :extension => gist_extension}]
       end
 
-      url = write(files, private_gist)
+      url = write(files, private_gist, description)
       browse(url) if browse_enabled
-      copy(url) if copy
-      $stdout.tty? ? puts(url) : print(url)
+      puts copy(url)
     rescue => e
       warn e
       puts opts
     end
   end
 
-  def write(files, private_gist = false)
-    url = URI.parse(CREATE_URL)
+  def write(files, private_gist = false, description = nil)
+    url = URI.parse(create_url)
 
     if PROXY_HOST
       proxy = Net::HTTP::Proxy(PROXY_HOST, PROXY_PORT)
@@ -193,30 +224,35 @@ module Gist
       http = Net::HTTP.new(url.host, url.port)
     end
 
-    http.use_ssl = true
+    http.use_ssl = /^https$/.match(url.scheme) ? true : false
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.ca_file = ca_cert
-
+    
     req = Net::HTTP::Post.new(url.path)
-    req.form_data = data(files, private_gist)
-
+    pl = payload(files, private_gist, description)
+    req.body = pl.to_json
     response = http.start{|h| h.request(req) }
+    res_obj = JSON.parse(response.body)
     case response
-    when Net::HTTPRedirection
-      response['Location']
+    when Net::HTTPCreated
+      res_obj["html_url"]
     else
       puts "Creating gist failed: #{response.code} #{response.message}"
+      puts response.body
       exit(false)
     end
   end
 
   def read(gist_id)
-    open(GIST_URL % gist_id).read
+    gist_url = get_url
+    open(gist_url % gist_id).read
   end
 
   def browse(url)
     if RUBY_PLATFORM =~ /darwin/
       `open #{url}`
+    elsif RUBY_PLATFORM =~ /linux/
+       `#{ENV['BROWSER']} #{url}`
     elsif ENV['OS'] == 'Windows_NT' or
       RUBY_PLATFORM =~ /djgpp|(cyg|ms|bcc)win|mingw|wince/i
       `start "" "#{url}"`
@@ -241,15 +277,16 @@ module Gist
   end
 
 private
-  def data(files, private_gist)
-    data = {}
+  def payload(files, private_gist, description)
+    payload = {
+      "description" => description,
+      "public"      => !private_gist,
+      "files"       => {}
+    }
     files.each do |file|
-      i = data.size + 1
-      data["file_ext[gistfile#{i}]"]      = file[:extension] ? file[:extension] : '.txt'
-      data["file_name[gistfile#{i}]"]     = file[:filename]
-      data["file_contents[gistfile#{i}]"] = file[:input]
+      payload["files"][file[:filename]] = { "content" => file[:input] }
     end
-    data.merge(private_gist ? { 'action_button' => 'private' } : {}).merge(auth)
+    payload
   end
 
   def auth
@@ -265,29 +302,20 @@ private
 
   def defaults
     extension = config("gist.extension")
-    extension = nil if extension && extension.empty?
-    
-    copy = config("gist.copy")
-    if copy.nil?
-      copy = true
-    else
-      # match optparse boolean true states
-      copy = copy =~ /^(true)|(on)|(\+)/
-    end
 
     return {
       "private"   => config("gist.private"),
       "browse"    => config("gist.browse"),
       "extension" => extension,
-      "copy"      => copy,
+      "url"       => config("gist.url")
     }
   end
 
   def config(key)
     env_key = ENV[key.upcase.gsub(/\./, '_')]
-    return env_key if env_key and not env_key.empty?
+    return env_key if env_key and not env_key.strip.empty?
 
-    str_to_bool `git config --global #{key}`.strip
+    str_to_bool `git config #{key}`.strip
   end
 
   def str_to_bool(str)
@@ -330,7 +358,7 @@ __END__
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIST" "1" "April 2011" "GITHUB" "Gist Manual"
+.TH "GIST" "1" "June 2011" "GITHUB" "Gist Manual"
 .
 .SH "NAME"
 \fBgist\fR \- gist on the command line
@@ -348,7 +376,7 @@ If standard input is supplied, it will be used as the content of the new gist\. 
 Once your gist is successfully created, the URL will be copied to your clipboard\. If you are on OS X, \fBgist\fR will open the gist in your browser, too\.
 .
 .SH "OPTIONS"
-\fBgist\fR\'s default mode of operation is to read content from standard input and create a public, text gist from it, tied to your GitHub account if you user and token are provided (see \fBCONFIGURATION\fR)\.
+\fBgist\fR\'s default mode of operation is to read content from standard input and create a public, text gist without description from it, tied to your GitHub account if you user and token are provided (see \fBCONFIGURATION\fR)\.
 .
 .P
 These options can be used to change this behavior:
@@ -359,7 +387,11 @@ Create a private gist instead of a public gist\.
 .
 .TP
 \fB\-t\fR, \fB\-\-type\fR
-Set the file extension explicitly\. Passing a type of \fBrb\fR ensure the gist is created as a Ruby file\.
+Set the file extension explicitly\. Passing a type of \fBrb\fR ensures the gist is created as a Ruby file\.
+.
+.TP
+\fB\-d\fR, \fB\-\-description\fR
+Set a description\.
 .
 .TP
 \fB\-o\fR, \fB\-\-[no\-]open\fR
@@ -380,7 +412,7 @@ Display this man page\.
 There are two ways to set GitHub user and token info:
 .
 .IP "\(bu" 4
-Using env vars GITHUB_USER and GITHUB_TOKEN
+Using environment vars GITHUB_USER and GITHUB_TOKEN
 .
 .IP
 $ export GITHUB_USER=johndoe


### PR DESCRIPTION
These changes make it possible to use gist with github enterprise by using the github API and allowing the gist url to be specified either in the CLI or in the local .git/config file.
