### PR TITLE
Fix the gist.copy config option

### DIFF
--- a/gist
+++ b/gist
@@ -270,9 +270,6 @@ private
     copy = config("gist.copy")
     if copy.nil?
       copy = true
-    else
-      # match optparse boolean true states
-      copy = copy =~ /^(true)|(on)|(\+)/
     end
 
     return {


### PR DESCRIPTION
str_to_bool already handles string values such as 'true' and 'on'.
Trying to do a regexp match on the boolean variable returned from the
config method will just result in that value to always be false, which
means that the gist.copy config value doesn't work as expected.
Removing this check fixes the problem.
