### PR TITLE
Fix public gist creation

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -207,7 +207,7 @@ private
 
     data = {"files" => file_data}
     data.merge!({ 'description' => description }) unless description.nil?
-    data.merge!({ 'public' => false }) if private_gist
+    data.merge!({ 'public' => ! private_gist })
     data
   end
 


### PR DESCRIPTION
Allow posting a public gist - I think github changed the default to be private, because if the 'public' attribute is not there it seems to default that way
