### PR TITLE
Support using an oauth token rather than a username+password

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,9 +56,32 @@ the quick brown fox jumps over the lazy dog
 
 Authentication
 --------------
-There are two ways to set GitHub user and password info:
+There are three ways to set GitHub authentication info:
 
-Using env vars GITHUB_USER and GITHUB_PASSWORD:
+__Generating an oauth token for gist access:__
+
+Set your github username either in an environment variable or the git config:
+```bash
+$ GITHUB_USER="your-github-username"
+$ # (or)
+$ git config --global github.user "your-github-username"
+```
+
+Generate an oauth token that can write gists:
+
+```bash
+$ curl -s -u${GITHUB_USER:-$(git config --global github.user)} -d '{ "scopes": [ "gist" ], "note": "gist cli" }' https://api.github.com/authorizations | grep '"token"' | cut -d\" -f4
+Enter host password for user 'your-github-username':
+9ba165eb3147168e9e56bdc1c997c8d0fd4fe25c
+```
+
+Set that token in your git config:
+
+```bash
+$ git config --global github.gist-oauth-token 9ba165eb3147168e9e56bdc1c997c8d0fd4fe25c
+```
+
+__Using env vars GITHUB_USER and GITHUB_PASSWORD:__
 
 ```bash
 $ export GITHUB_USER="your-github-username"
@@ -66,7 +89,7 @@ $ export GITHUB_PASSWORD="your-github-password"
 $ gist ~/example
 ```
 
-Or by having your git config set up with your GitHub username and password.
+__Using git config options github.user and github.password__
 
 ```bash
 git config --global github.user "your-github-username"

--- a/gist
+++ b/gist
@@ -1226,10 +1226,16 @@ module Gist
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.ca_file = ca_cert
 
-    req = Net::HTTP::Post.new(url.path)
+
+    user, password, gist_oauth_token = auth()
+    if gist_oauth_token
+      req = Net::HTTP::Post.new(url.path + "?access_token=%s" % gist_oauth_token)
+    else
+      req = Net::HTTP::Post.new(url.path)
+    end
+
     req.body = JSON.generate(data(files, private_gist, description))
 
-    user, password = auth()
     if user && password
       req.basic_auth(user, password)
     end
@@ -1296,16 +1302,17 @@ private
   def auth
     user  = config("github.user")
     password = config("github.password")
+    gist_oauth_token = config("github.gist-oauth-token")
 
     token = config("github.token")
-    if password.to_s.empty? && !token.to_s.empty?
+    if password.to_s.empty? && !token.to_s.empty? && gist_oauth_token.to_s.empty?
       abort "Please set GITHUB_PASSWORD or github.password instead of using a token."
     end
 
-    if user.to_s.empty? || password.to_s.empty?
+    if (user.to_s.empty? || password.to_s.empty?) && gist_oauth_token.to_s.empty?
       nil
     else
-      [ user, password ]
+      [ user, password, gist_oauth_token ]
     end
   end
 
@@ -1320,7 +1327,7 @@ private
   end
 
   def config(key)
-    env_key = ENV[key.upcase.gsub(/\./, '_')]
+    env_key = ENV[key.upcase.gsub(/[-.]/, '_')]
     return env_key if env_key and not env_key.strip.empty?
 
     str_to_bool `git config --global #{key}`.strip


### PR DESCRIPTION
This is rather basic oauth token support.  The most interesting part is probably the curl command to generate an oauth token that can create gists.

It should help address the security concerns in defunkt#84, though.
