### PR TITLE
use file basename by default

### DIFF
--- a/gist
+++ b/gist
@@ -1140,6 +1140,7 @@ module Gist
     gist_extension = defaults["extension"]
     browse_enabled = defaults["browse"]
     description = nil
+    use_basename = true
 
     opts = OptionParser.new do |opts|
       opts.banner = "Usage: gist [options] [filename or stdin] [filename] ...\n" +
@@ -1171,6 +1172,10 @@ module Gist
         exit
       end
 
+      opts.on('-b', '--[no-]basename', 'use the basename of the given file (enabled by default)') do |b|
+        use_basename = b
+      end
+
       opts.on('-h', '--help', 'Display this screen') do
         puts opts
         exit
@@ -1193,7 +1198,7 @@ module Gist
 
           files.push({
             :input     => File.read(file),
-            :filename  => file,
+            :filename  => (use_basename ? File.basename(file) : file),
             :extension => (File.extname(file) if file.include?('.'))
           })
         end


### PR DESCRIPTION
The github API doesn't seem to like file names with a '/' in it, like
you would get if you executed `gist /tmp/foo.txt` or
`gist subdir/bar.c`.  This yields a "422 Unprocessable Entity" error
which can be very confusing.  Using the file's basename eliminates this
problem.  This behavior can be disabled by passing `--no-basename` to
gist.
