### PR TITLE
Add reading of gists.

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -45,11 +45,16 @@ module Gist
     gist_filename = nil
     gist_extension = defaults["extension"]
     browse_enabled = defaults["browse"]
+    read_mode = false
     description = nil
 
     opts = OptionParser.new do |opts|
       opts.banner = "Usage: gist [options] [filename or stdin] [filename] ...\n" +
         "Filename '-' forces gist to read from stdin."
+
+      opts.on('-r', '--read', 'Get the gist for the given id') do
+        read_mode = true
+      end
 
       opts.on('-p', '--[no-]private', 'Make the gist private') do |priv|
         private_gist = priv
@@ -93,6 +98,14 @@ module Gist
         if args.empty?
           # No args, print help.
           puts opts
+          exit
+        end
+
+        if read_mode
+          args.each do |gist_id|
+            next if gist_id =~ /^\_/
+            puts Gist.read(gist_id)
+          end
           exit
         end
 


### PR DESCRIPTION
Allows for reading of gists in the format

```
gist -r GIST_ID
```

This fixes issue #21

Credit to @nobbs, this feature is based of [his old fork](https://github.com/defunkt/gist/issues/21#issuecomment-2347150).
