### PR TITLE
set Content-Type.

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -138,6 +138,7 @@ module Gist
     http.ca_file = ca_cert
 
     req = Net::HTTP::Post.new(url.path)
+    req.set_content_type("application/json")
     req.body = JSON.generate(data(files, private_gist, description))
 
     user, password = auth()


### PR DESCRIPTION
If does not set content-type, it seems that can't post `%`. I got `why this get fail` from github support.
