### PR TITLE
Support to post files including '%'

### DIFF
--- a/gist
+++ b/gist
@@ -1227,6 +1227,7 @@ module Gist
     http.ca_file = ca_cert
 
     req = Net::HTTP::Post.new(url.path)
+    req.add_field("Content-Type", "application/json")
     req.body = JSON.generate(data(files, private_gist, description))
 
     user, password = auth()

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -138,6 +138,7 @@ module Gist
     http.ca_file = ca_cert
 
     req = Net::HTTP::Post.new(url.path)
+    req.add_field("Content-Type", "application/json")
     req.body = JSON.generate(data(files, private_gist, description))
 
     user, password = auth()


### PR DESCRIPTION
I can't post files including '%'. So I add Content-type header to HTTP request.
