### PR TITLE
Allow gist to work against different githubs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -97,6 +97,23 @@ control the default behavior of gist(1).
 * gist.browse - boolean (yes or no) - Whether to open the gist in your
   browser after creation. Default: yes
 
+GitHub Enterprise
+-----------------
+
+If you're a GitHub Enterprise user you can point gist at your
+installation using environment variables or with git config:
+
+```bash
+$ export GITHUB_URL=https://my.github.com/api/v3
+```
+
+```bash
+$ git config --global github.url https://my.github.com/api/v3
+```
+
+You'll need to have the authentication details for your GitHub install
+setup as above for this to work.
+
 Proxies
 -------
 

--- a/gist
+++ b/gist
@@ -1121,9 +1121,6 @@ require 'gist/version' unless defined?(Gist::Version)
 module Gist
   extend self
 
-  GIST_URL   = 'https://api.github.com/gists/%s'
-  CREATE_URL = 'https://api.github.com/gists'
-
   if ENV['HTTPS_PROXY']
     PROXY = URI(ENV['HTTPS_PROXY'])
   elsif ENV['HTTP_PROXY']
@@ -1213,7 +1210,7 @@ module Gist
   end
 
   def write(files, private_gist = false, description = nil)
-    url = URI.parse(CREATE_URL)
+    url = URI.parse(gist_url)
 
     if PROXY_HOST
       proxy = Net::HTTP::Proxy(PROXY_HOST, PROXY_PORT)
@@ -1245,7 +1242,7 @@ module Gist
   end
 
   def read(gist_id)
-    data = JSON.parse(open(GIST_URL % gist_id).read)
+    data = JSON.parse(open('%s/%s' % [ gist_url, gist_id ]).read)
     data["files"].map{|name, content| content['content'] }.join("\n\n")
   end
 
@@ -1307,6 +1304,14 @@ private
     else
       [ user, password ]
     end
+  end
+
+  def github_url
+    config('github.url') || 'https://api.github.com'
+  end
+
+  def gist_url
+    github_url + '/gists'
   end
 
   def defaults

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -26,9 +26,6 @@ require 'gist/version' unless defined?(Gist::Version)
 module Gist
   extend self
 
-  GIST_URL   = 'https://api.github.com/gists/%s'
-  CREATE_URL = 'https://api.github.com/gists'
-
   if ENV['HTTPS_PROXY']
     PROXY = URI(ENV['HTTPS_PROXY'])
   elsif ENV['HTTP_PROXY']
@@ -124,7 +121,7 @@ module Gist
 
   # Create a gist on gist.github.com
   def write(files, private_gist = false, description = nil)
-    url = URI.parse(CREATE_URL)
+    url = URI.parse(gist_url)
 
     if PROXY_HOST
       proxy = Net::HTTP::Proxy(PROXY_HOST, PROXY_PORT)
@@ -157,7 +154,7 @@ module Gist
 
   # Given a gist id, returns its content.
   def read(gist_id)
-    data = JSON.parse(open(GIST_URL % gist_id).read)
+    data = JSON.parse(open('%s/%s' % [ gist_url, gist_id ]).read)
     data["files"].map{|name, content| content['content'] }.join("\n\n")
   end
 
@@ -229,6 +226,16 @@ private
     else
       [ user, password ]
     end
+  end
+
+  # return the API url for github
+  def github_url
+    config('github.url') || 'https://api.github.com'
+  end
+
+  # return API url for making gists
+  def gist_url
+    github_url + '/gists'
   end
 
   # Returns default values based on settings in your gitconfig. See


### PR DESCRIPTION
Some of us work for places that use GitHub Enterprise :)

Decided to call the config 'github.url' which is a bit confusing as it's actually the URL for the API (which includes /api/v3 for enterprise GH).

Briefly tested against public and private GitHubs.
