### PR TITLE
Refactor reading from stdin so --type option works

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -119,7 +119,7 @@ module Gist
         files = [{
           :input     => input,
           :extension => gist_extension,
-          :filename  => Time.now.utc.to_s.gsub(/\W/, '') + gist_extension
+          :filename  => Time.now.utc.to_s.gsub(/\W/, '') + gist_extension.to_s
         }]
       end
 


### PR DESCRIPTION
When reading from stdin, a filename must be set with an extension since the GitHub gist API infers file type from filename and not extension. Thanks to @ottomata for the original implementation. Fixes Issue #101.
