### PR TITLE
git 1.7.10 include directive and Local GitHub Config

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -258,7 +258,7 @@ private
     env_key = ENV[key.upcase.gsub(/\./, '_')]
     return env_key if env_key and not env_key.strip.empty?
 
-    str_to_bool `git config --global #{key}`.strip
+    str_to_bool `git config #{key}`.strip
   end
 
   # Parses a value that might appear in a .gitconfig file into


### PR DESCRIPTION
The git 1.7.10 include directive [1] allows you to include external files from your .gitconfig. But these directives are not read by `git config --global github.user`, only by `git config github.user`.

In light of this, I think it makes sense for gist to use the latter rather than the former.

The same change was made to gh.el in sigma/gh.el#5.

https://github.com/gitster/git/commit/9b25a0b52e09400719366f0a33d0d0da98bbf7b0
