### PR TITLE
simplify keychain access example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,7 +80,7 @@ password from an item named "github.password" on the Mac OS
 Keychain:
 
 ```bash
-password = !security 2>&1 >/dev/null find-generic-password -gs github.password | ruby -e 'print $1 if STDIN.gets =~ /^password: \\\"(.*)\\\"$/'
+password = !security 2>&1 >/dev/null find-generic-password -gs github.password -w | tr -d '\n'
 ```
 
 Defaults


### PR DESCRIPTION
There's no need for ruby execution--security has a flag to output the password only (`-w`).
