### PR TITLE
Preventing gist from throwing errors when xclip is installed but X11 isn't present (forwarding or otherwise)

### DIFF
--- a/gist
+++ b/gist
@@ -1264,7 +1264,7 @@ module Gist
     cmd = case true
     when system("type pbcopy > /dev/null 2>&1")
       :pbcopy
-    when system("type xclip > /dev/null 2>&1")
+    when system("type xclip > /dev/null 2>&1") && !ENV['DISPLAY'].empty?
       :xclip
     when system("type putclip > /dev/null 2>&1")
       :putclip


### PR DESCRIPTION
If someone has xclip installed on a remote machine but isn't forwarding X11 at the time (or even locally for various reasons), it will throw a broken pipe error. This prevents that by checking the environment variable display before attempting to throw the gist url into xclip
