### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,8 +76,16 @@ git config --global github.password "your-github-password"
 You can also define github.password to be a command which returns the
 actual password on stdout by setting the variable to a command string
 prefixed with `!`. For example, the following command fetches the
-password from an item named "github.password" on the Mac OS
-Keychain:
+password from the Mac OS Keychain entry for the GitHub website (if you
+allow your browser to save passwords):
+
+```bash
+password = !security find-internet-password -u <your github username> -s github.com -w | tr -d '\n'
+```
+
+If you don't allow your browser to save passwords, you can use the following
+to fetch the password from a Keychain entry named "github.password" (you'll
+also need to create the Keychain entry):
 
 ```bash
 password = !security find-generic-password -gs github.password -w | tr -d '\n'


### PR DESCRIPTION
Added a more convenient example of retrieving the GitHub password from the Mac OS keychain. Using "find-internet-password" instead of "find-generic-password" means that a user need not maintain the Keychain entry manually if they change their password, as it will be updated automatically by their browser when they next log into the GitHub website successfully.
