### PR TITLE
Add "Print embed code" option.

### DIFF
--- a/gist
+++ b/gist
@@ -1140,6 +1140,7 @@ module Gist
     gist_extension = defaults["extension"]
     browse_enabled = defaults["browse"]
     description = nil
+    embed_enabled = nil
 
     opts = OptionParser.new do |opts|
       opts.banner = "Usage: gist [options] [filename or stdin] [filename] ...\n" +
@@ -1160,6 +1161,10 @@ module Gist
 
       opts.on('-o','--[no-]open', 'Open gist in browser') do |o|
         browse_enabled = o
+      end
+
+      opts.on('-e', '--embed', 'Print javascript embed code') do |o|
+        embed_enabled = o
       end
 
       opts.on('-m', '--man', 'Print manual') do
@@ -1205,11 +1210,16 @@ module Gist
 
       url = write(files, private_gist, description)
       browse(url) if browse_enabled
-      puts copy(url)
+      puts copy(to_embed(url)) if embed_enabled
+      puts copy(url) unless embed_enabled
     rescue => e
       warn e
       puts opts
     end
+  end
+
+  def to_embed(url)
+    %Q[<script src="#{url}.js"></script>]
   end
 
   def write(files, private_gist = false, description = nil)
@@ -1366,7 +1376,7 @@ __END__
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIST" "1" "March 2012" "GITHUB" "Gist Manual"
+.TH "GIST" "1" "February 2013" "GITHUB" "Gist Manual"
 .
 .SH "NAME"
 \fBgist\fR \- gist on the command line

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -46,6 +46,7 @@ module Gist
     gist_extension = defaults["extension"]
     browse_enabled = defaults["browse"]
     description = nil
+    embed_enabled = nil
 
     opts = OptionParser.new do |opts|
       opts.banner = "Usage: gist [options] [filename or stdin] [filename] ...\n" +
@@ -66,6 +67,10 @@ module Gist
 
       opts.on('-o','--[no-]open', 'Open gist in browser') do |o|
         browse_enabled = o
+      end
+
+      opts.on('-e', '--embed', 'Print javascript embed code') do |o|
+        embed_enabled = o
       end
 
       opts.on('-m', '--man', 'Print manual') do
@@ -115,11 +120,17 @@ module Gist
 
       url = write(files, private_gist, description)
       browse(url) if browse_enabled
-      puts copy(url)
+      puts copy(to_embed(url)) if embed_enabled
+      puts copy(url) unless embed_enabled
     rescue => e
       warn e
       puts opts
     end
+  end
+
+  # Create a javascript embed code
+  def to_embed(url)
+    %Q[<script src="#{url}.js"></script>]
   end
 
   # Create a gist on gist.github.com

--- a/man/gist.1
+++ b/man/gist.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIST" "1" "November 2012" "GITHUB" "Gist Manual"
+.TH "GIST" "1" "February 2013" "GITHUB" "Gist Manual"
 .
 .SH "NAME"
 \fBgist\fR \- gist on the command line

--- a/man/gist.1.html
+++ b/man/gist.1.html
@@ -200,7 +200,7 @@ the quick brown fox jumps over the lazy dog
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>GITHUB</li>
-    <li class='tc'>November 2012</li>
+    <li class='tc'>February 2013</li>
     <li class='tr'>gist(1)</li>
   </ol>
 


### PR DESCRIPTION
-e or --embed option will be copied to the clipboard JavaScript embed code . and print stdout.

I am a blogger in Japan.
I have often used the gist command.

When my embed the code on my blog because they use the embed code gist, I've added the option to be able to get the embed code.
