### PR TITLE
Replace slashes with dashes to avoid 422 errors

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -102,7 +102,7 @@ module Gist
 
           files.push({
             :input     => File.read(file),
-            :filename  => file,
+            :filename  => file.gsub("/", "-"),
             :extension => (File.extname(file) if file.include?('.'))
           })
         end


### PR DESCRIPTION
When gisting a file from a subdirectory, e.g.:

```
$ gist dir/file.txt
```

the gist API will return a 422 error, because it doesn't like slashes in filenames.

This patch makes sure slashes are converted to dashes. I chose this solution over something like `File.basename` so that files with the same name from different subdirectories can still be gisted at the same time.
