### PR TITLE
Set config file permissions to prevent group/world read

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -166,7 +166,7 @@ module Gist
     response = http(api_url, request)
 
     if Net::HTTPCreated === response
-      File.open(auth_token_file, 'w') do |f|
+      File.open(auth_token_file, 'w', 0600) do |f|
         f.write JSON.parse(response.body)['token']
       end
       puts "Success! #{ENV[URL_ENV_NAME] || "https://github.com/"}settings/applications"


### PR DESCRIPTION
This ensures that when creating the authentication token file, the permission is set to owner-only read/write.

This doesn't change permissions on any existing files; I didn't see an obvious place to do that, and there are other implications to having the gem modify permissions that may have been changed intentionally, but I believe it's worth considering a warning that the permissions are lax, similar to the warning shown by `gem` for lax permissions on ~/.gem/credentials.
