### PR TITLE
Fix a bug causeing `gist -c` fails for xsel users.

### DIFF
--- a/build/gist
+++ b/build/gist
@@ -1318,7 +1318,7 @@ module Gist
   # A list of clipboard commands with copy and paste support.
   CLIPBOARD_COMMANDS = {
     'xclip'   => 'xclip -o',
-    'xsel'    => 'xsel -o',
+    'xsel -i'    => 'xsel -o',
     'pbcopy'  => 'pbpaste',
     'putclip' => 'getclip'
   }

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -12,7 +12,7 @@ module Gist
   # A list of clipboard commands with copy and paste support.
   CLIPBOARD_COMMANDS = {
     'xclip'   => 'xclip -o',
-    'xsel'    => 'xsel -o',
+    'xsel -i'    => 'xsel -o',
     'pbcopy'  => 'pbpaste',
     'putclip' => 'getclip'
   }


### PR DESCRIPTION
Unlike `xclip`, calling `xsel` without any argument outputs the selection.
In other words, `xclip` defaults to `xclip -i`, but xsel`defaults to`xsel -o`.

Thus we should use `xsel -i` instead of `xsel` for copying the url to clipboard.
