### PR TITLE
improve install instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ upload content to https://gist.github.com/.
 
     gem install gist
 
+Note: Debian/Ubuntu users should install the ruby dev package (which includes mkmf.rb) before running the above command.
+ruby dev can be installed via `sudo apt-get install ruby1.9-dev`.
+
 ‌If you're using Bundler:
 
     source :rubygems


### PR DESCRIPTION
If a Debian/Ubuntu user have not  installed ruby1.9-dev before, when they use `gem install gist`, they will get this error:

```

$ sudo gem install gist
Building native extensions.  This could take a while...
ERROR:  Error installing gist:
        ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
        from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from extconf.rb:1:in `<main>'
```

This is because `mkmf.rb` is missing on their system.

Thus they need to install `mkmf.rb`, which is included in the `ruby1.9-dev` package.

After that, `gem install gist` works.
