### PR TITLE
Improve auth-token file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ so if you run into errors, update the gist gem.
 
     gem update gist
 
-This token is stored in `~/.gist` and used for all future gisting. If you need to
-you can revoke it from https://github.com/settings/applications, or just delete the
-file.  If you need to store tokens for both github.com and a Github Enterprise instance 
-you can save your Github Enterprise token in `~/.gist.github.example.com` where 
-"github.example.com" is the URL for your Github Enterprise instance.
+On Linux this token is stored at `$XDG_CONFIG_HOME/gist/token`, on OSX at
+`~/Library/gist/token`, and on all other platforms at `~/.gist` and is used for all future
+gisting. If you need to you can revoke it from https://github.com/settings/applications,
+or just delete the file.  If you need to store tokens for both github.com and a Github
+Enterprise instance you can save your Github Enterprise token as
+`token.github.example.com` where "github.example.com" is the URL for your Github
+Enterprise instance.
 
 ‌After you've done this, you can still upload gists anonymously with `-a`.
 
@@ -102,7 +104,7 @@ you can save your Github Enterprise token in `~/.gist.github.example.com` where
 
 If you need more advanced features you can also pass:
 
-* `:access_token` to authenticate using OAuth2 (default is `File.read("~/.gist")).
+* `:access_token` to authenticate using OAuth2 (default is `File.read(auth_token_file)`).
 * `:filename` to change the syntax highlighting (default is `a.rb`).
 * `:public` if you want your gist to have a guessable url.
 * `:description` to add a description to your gist.
@@ -123,7 +125,7 @@ NOTE: The access_token must have the "gist" scope.
     Gist.login!
 
 ‌This will take them through the process of obtaining an OAuth2 token, and storing it
-in `~/.gist`, where it can later be read by `Gist.gist`
+in the `auth_token_file`, where it can later be read by `Gist.gist`
 
 ## GitHub enterprise
 


### PR DESCRIPTION
Note: _This pull request isn't acceptable in it's current state, but I would like to open a dialog with a few questions!_

This PR provides a better place to store the `.gist` file on both OSX and Linux.
- For OSX the authentication token file is stored under `~/Library/Caches/gist` as specified by [this particular Apple technical Q/A](https://developer.apple.com/library/mac/qa/qa1170/_index.html#//apple_ref/doc/uid/DTS10001702-CH1-SECTION5).
- For Linux the authentication token is stored as `$XDG_CACHE_HOME/gist`, conforming to the [XDG Base Directory Specifications](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html). 
##### My questions are:
1. Should we consider the auth-token file a piece of cached information, or persistent information? I asked this question on [the Arch Linux forums](https://bbs.archlinux.org/viewtopic.php?id=173297) a little while ago, but only had one response.
2. How should I handle migration of the `~/.gist` file? When I opened a [similar PR](https://github.com/ConradIrwin/jist/pull/37) on the jist gem it was recomended that I do one of the two:
   1. Move the original `~/.gist` file into the proper location. If I do this where should the logic reside in the code to handle moving the file?
   2. Just read the original `~/.gist` file if it exists.
