### PR TITLE
[Linux] Copy to CLIPBOARD buffer instead of the PRIMARY buffer

### DIFF
--- a/build/gist
+++ b/build/gist
@@ -1322,10 +1322,10 @@ module Gist
 
   # A list of clipboard commands with copy and paste support.
   CLIPBOARD_COMMANDS = {
-    'xclip'   => 'xclip -o',
-    'xsel -i'    => 'xsel -o',
-    'pbcopy'  => 'pbpaste',
-    'putclip' => 'getclip'
+    'xclip -se c' => 'xclip -se c -o',
+    'xsel -bi'    => 'xsel -b',
+    'pbcopy'      => 'pbpaste',
+    'putclip'     => 'getclip'
   }
 
   GITHUB_API_URL   = URI("https://api.github.com/")

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -16,10 +16,10 @@ module Gist
 
   # A list of clipboard commands with copy and paste support.
   CLIPBOARD_COMMANDS = {
-    'xclip'   => 'xclip -o',
-    'xsel -i'    => 'xsel -o',
-    'pbcopy'  => 'pbpaste',
-    'putclip' => 'getclip'
+    'xclip -se c' => 'xclip -se c -o',
+    'xsel -bi'    => 'xsel -b',
+    'pbcopy'      => 'pbpaste',
+    'putclip'     => 'getclip'
   }
 
   GITHUB_API_URL   = URI("https://api.github.com/")


### PR DESCRIPTION
This changes the `xclip` and `xsel` commands to copy and paste to and from the CLIPBOARD buffer instead of the PRIMARY buffer under linux.

This will fix (part of) #157 also.
