### PR TITLE
[Linux] Support the xdg-open command

### DIFF
--- a/build/gist
+++ b/build/gist
@@ -1635,6 +1635,7 @@ Could not find copy command, tried:
               elsif RUBY_PLATFORM =~ /linux/
                 %w(
                   sensible-browser
+                  xdg-open
                   firefox
                   firefox-bin
                 ).detect do |cmd|

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -329,6 +329,7 @@ Could not find copy command, tried:
               elsif RUBY_PLATFORM =~ /linux/
                 %w(
                   sensible-browser
+                  xdg-open
                   firefox
                   firefox-bin
                 ).detect do |cmd|


### PR DESCRIPTION
The `xdg-open` command can be used similar to OSX's `open` command. It will open the URL with the users preferred application to handle http:// protocol URIs. [Here's some good documentation on the command](http://uce.uniovi.es/tips/Linux/xdg-open.html).
