### PR TITLE
Chomp OAuth access token before use.

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -44,7 +44,7 @@ module Gist
   #
   # @return [String] string value of access token or `nil`, if not found
   def auth_token
-    @token ||= File.read(auth_token_file) rescue nil
+    @token ||= File.read(auth_token_file).chomp rescue nil
   end
 
   # Upload a gist to https://gist.github.com


### PR DESCRIPTION
If a user is modifying the .gist file by hand there is a big risk that the
user adds a newline to the file. That newline is causing gist to fail with
"Error: Got Net::HTTPUnauthorized from gist:".
So better remove the eventual newline with chomp before use.

This is extra handy when setting up gist on an computer that you don't trust
with your real GitHub credentials (pre-generated OAuth token).
