### PR TITLE
XDG directory compliance for auth token

### DIFF
--- a/gist.gemspec
+++ b/gist.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ronn'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'rspec', '>3'
+  s.add_development_dependency 'rspec-its'
 end

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -59,7 +59,7 @@ module Gist
     end
 
     def pathname
-      xdg? ? xdg_path : legacy_path
+      (xdg? ? xdg_path : legacy_path).to_pathname
     end
 
     def xdg?
@@ -67,21 +67,15 @@ module Gist
     end
 
     def legacy_path
-      pathname_for "~/.gist"
+      @legacy_path
     end
 
     def xdg_path
-      pathname_for XDG.cache "gist/auth_token"
+      @xdg_path
     end
 
     def github_url_suffix
       ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
-    end
-
-    private
-
-    def pathname_for(p)
-      Pathname.new(p.concat(github_url_suffix)).expand_path
     end
   end
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -68,6 +68,10 @@ module Gist
     def self.cache_home
       ENV.fetch(CACHE_HOME_ENV_NAME, "~/.cache")
     end
+
+    def self.cache(file)
+      File.expand_path File.join cache_home, file
+    end
   end
 
   # auth token for authentication

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -42,10 +42,6 @@ module Gist
 
   # helper module for authentication token actions
   module AuthTokenFile
-    def self.filename
-      File.expand_path "~/.gist#{github_url_suffix}"
-    end
-
     def self.read
       File.read(filename).chomp
     end
@@ -54,6 +50,10 @@ module Gist
       File.open(filename, 'w', 0600) do |f|
         f.write token
       end
+    end
+
+    def self.filename
+      xdg? ? xdg_path : legacy_path
     end
 
     def self.xdg?

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -57,18 +57,18 @@ module Gist
     end
 
     def self.xdg?
-      File.exist?(xdg_filename) || !File.exist?(legacy_filename)
+      File.exist?(xdg_path) || !File.exist?(legacy_path)
     end
 
     def self.github_url_suffix
       ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
     end
 
-    def self.legacy_filename
+    def self.legacy_path
       File.expand_path "~/.gist#{github_url_suffix}"
     end
 
-    def self.xdg_filename
+    def self.xdg_path
       File.expand_path XDG.cache "gist/auth_token#{github_url_suffix}"
     end
   end

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -56,6 +56,10 @@ module Gist
       end
     end
 
+    def self.xdg?
+      File.exist? XDG.cache("gist")
+    end
+
     def self.github_url_suffix
       ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
     end

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -62,6 +62,14 @@ module Gist
 
   end
 
+  class XDG
+    CACHE_HOME_ENV_NAME = "XDG_CACHE_HOME"
+
+    def self.cache_home
+      ENV.fetch(CACHE_HOME_ENV_NAME, "~/.cache")
+    end
+  end
+
   # auth token for authentication
   #
   # @return [String] string value of access token or `nil`, if not found

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -43,6 +43,11 @@ module Gist
 
   # helper module for authentication token actions
   class AuthTokenFile
+    def initialize
+      @xdg_path = AuthTokenPathname.new XDG.cache "gist/auth_token"
+      @legacy_path = AuthTokenPathname.new "~/.gist"
+    end
+
     def read
       pathname.read.chomp
     end
@@ -58,7 +63,7 @@ module Gist
     end
 
     def xdg?
-      xdg_path.exist? || !legacy_path.exist?
+      @xdg_path.exist? || !@legacy_path.exist?
     end
 
     def legacy_path

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -93,6 +93,14 @@ module Gist
     def exist?
       !Dir.glob("#{@path}*").empty?
     end
+
+    def to_pathname
+      Pathname.new "#{@path}#{github_url_suffix}"
+    end
+
+    def github_url_suffix
+      ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
+    end
   end
 
   class XDG

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -43,39 +43,39 @@ module Gist
 
   # helper module for authentication token actions
   class AuthTokenFile
-    def self.read
+    def read
       pathname.read.chomp
     end
 
-    def self.write(token)
+    def write(token)
       pathname.open('w', 0600) do |f|
         f.write token
       end
     end
 
-    def self.pathname
+    def pathname
       xdg? ? xdg_path : legacy_path
     end
 
-    def self.xdg?
+    def xdg?
       xdg_path.exist? || !legacy_path.exist?
     end
 
-    def self.legacy_path
+    def legacy_path
       pathname_for "~/.gist"
     end
 
-    def self.xdg_path
+    def xdg_path
       pathname_for XDG.cache "gist/auth_token"
     end
 
-    def self.github_url_suffix
+    def github_url_suffix
       ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
     end
 
     private
 
-    def self.pathname_for(p)
+    def pathname_for(p)
       Pathname.new(p.concat(github_url_suffix)).expand_path
     end
   end
@@ -96,7 +96,7 @@ module Gist
   #
   # @return [String] string value of access token or `nil`, if not found
   def auth_token
-    @token ||= AuthTokenFile.read rescue nil
+    @token ||= AuthTokenFile.new.read rescue nil
   end
 
   # Upload a gist to https://gist.github.com
@@ -310,7 +310,7 @@ module Gist
       end
 
       if Net::HTTPCreated === response
-        AuthTokenFile.write JSON.parse(response.body)['token']
+        AuthTokenFile.new.write JSON.parse(response.body)['token']
         puts "Success! #{ENV[URL_ENV_NAME] || "https://github.com/"}settings/applications"
         return
       elsif Net::HTTPUnauthorized === response

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -94,10 +94,8 @@ module Gist
   end
 
   class XDG
-    CACHE_HOME_ENV_NAME = "XDG_CACHE_HOME"
-
     def self.cache_home
-      ENV.fetch(CACHE_HOME_ENV_NAME, "~/.cache")
+      ENV.fetch("XDG_CACHE_HOME", "~/.cache")
     end
 
     def self.cache(file)

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -43,11 +43,7 @@ module Gist
   # helper module for authentication token actions
   module AuthTokenFile
     def self.filename
-      if ENV.key?(URL_ENV_NAME)
-        File.expand_path "~/.gist.#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}"
-      else
-        File.expand_path "~/.gist"
-      end
+      File.expand_path "~/.gist#{github_url_suffix}"
     end
 
     def self.read

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -59,6 +59,11 @@ module Gist
         f.write token
       end
     end
+
+    def self.github_url_suffix
+      ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
+    end
+
   end
 
   # auth token for authentication

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -94,12 +94,16 @@ module Gist
       !Dir.glob("#{@path}*").empty?
     end
 
-    def to_pathname
-      Pathname.new "#{@path}#{github_url_suffix}"
-    end
-
     def github_url_suffix
       ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
+    end
+
+    def to_s
+      "#{@path}#{github_url_suffix}"
+    end
+
+    def to_pathname
+      Pathname.new to_s
     end
   end
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -43,6 +43,8 @@ module Gist
 
   # helper module for authentication token actions
   class AuthTokenFile
+    attr_reader :xdg_path, :legacy_path
+
     def initialize
       @xdg_path = AuthTokenPathname.new XDG.cache "gist/auth_token"
       @legacy_path = AuthTokenPathname.new "~/.gist"
@@ -63,15 +65,7 @@ module Gist
     end
 
     def xdg?
-      @xdg_path.exist? || !@legacy_path.exist?
-    end
-
-    def legacy_path
-      @legacy_path
-    end
-
-    def xdg_path
-      @xdg_path
+      xdg_path.exist? || !legacy_path.exist?
     end
   end
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -73,10 +73,6 @@ module Gist
     def xdg_path
       @xdg_path
     end
-
-    def github_url_suffix
-      ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
-    end
   end
 
   class AuthTokenPathname

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -57,13 +57,20 @@ module Gist
     end
 
     def self.xdg?
-      File.exist? XDG.cache("gist")
+      File.exist?(xdg_filename) || !File.exist?(legacy_filename)
     end
 
     def self.github_url_suffix
       ENV.key?(URL_ENV_NAME) ? ".#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}" : ""
     end
 
+    def self.legacy_filename
+      File.expand_path "~/.gist#{github_url_suffix}"
+    end
+
+    def self.xdg_filename
+      File.expand_path XDG.cache "gist/auth_token#{github_url_suffix}"
+    end
   end
 
   class XDG
@@ -74,7 +81,7 @@ module Gist
     end
 
     def self.cache(file)
-      File.expand_path File.join cache_home, file
+      File.join cache_home, file
     end
   end
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -43,16 +43,16 @@ module Gist
   # helper module for authentication token actions
   class AuthTokenFile
     def self.read
-      File.read(filename).chomp
+      File.read(pathname).chomp
     end
 
     def self.write(token)
-      File.open(filename, 'w', 0600) do |f|
+      File.open(pathname, 'w', 0600) do |f|
         f.write token
       end
     end
 
-    def self.filename
+    def self.pathname
       xdg? ? xdg_path : legacy_path
     end
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -80,6 +80,16 @@ module Gist
     end
   end
 
+  class AuthTokenPathname
+    def initialize(path)
+      @path = Pathname.new(path).expand_path
+    end
+
+    def exist?
+      !Dir.glob("#{@path}*").empty?
+    end
+  end
+
   class XDG
     CACHE_HOME_ENV_NAME = "XDG_CACHE_HOME"
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -1,6 +1,7 @@
 require 'net/https'
 require 'cgi'
 require 'uri'
+require 'fileutils'
 require 'pathname'
 
 begin
@@ -55,6 +56,7 @@ module Gist
     end
 
     def write(token)
+      FileUtils.mkpath pathname.dirname
       pathname.open('w', 0600) do |f|
         f.write token
       end

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -41,7 +41,7 @@ module Gist
   class ClipboardError < RuntimeError; include Error end
 
   # helper module for authentication token actions
-  module AuthTokenFile
+  class AuthTokenFile
     def self.read
       File.read(filename).chomp
     end

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -44,11 +44,11 @@ module Gist
   # helper module for authentication token actions
   class AuthTokenFile
     def self.read
-      File.read(pathname.to_s).chomp
+      pathname.read.chomp
     end
 
     def self.write(token)
-      File.open(pathname.to_s, 'w', 0600) do |f|
+      pathname.open('w', 0600) do |f|
         f.write token
       end
     end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -116,6 +116,7 @@ describe Gist::AuthTokenPathname do
   context "with default GITHUB_URL" do
     before do ENV.delete Gist::URL_ENV_NAME end
 
+    its(:to_s) { should == File.expand_path(pathname) }
     its(:to_pathname) { should be_a_pathname_for pathname }
     its(:github_url_suffix) { should == "" }
   end
@@ -125,6 +126,7 @@ describe Gist::AuthTokenPathname do
     let(:github_url) { "gh.custom.org" }
     let(:github_url_suffix) { "." + github_url }
 
+    its(:to_s) { should == File.expand_path(pathname+github_url_suffix) }
     its(:to_pathname) { should be_a_pathname_for pathname+github_url_suffix }
     its(:github_url_suffix) { should == github_url_suffix }
   end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -1,8 +1,4 @@
 describe Gist::AuthTokenFile do
-  before(:each) do
-    stub_const("Gist::URL_ENV_NAME", "STUBBED_GITHUB_URL")
-  end
-
   describe "#read" do
     let(:token) { "auth_token" }
     let(:pathname) { double }
@@ -32,23 +28,6 @@ describe Gist::AuthTokenFile do
       token_file.should_receive(:write).with(token)
       subject.write(token)
     end
-  end
-
-  context "with default GITHUB_URL" do
-    before do ENV.delete Gist::URL_ENV_NAME end
-
-    its(:xdg_path) { should be_a_pathname_for File.expand_path "~/.cache/gist/auth_token" }
-    its(:legacy_path) { should be_a_pathname_for File.expand_path "~/.gist" }
-    its(:github_url_suffix) { should == "" }
-  end
-
-  context "with custom GITHUB_URL" do
-    before do ENV[Gist::URL_ENV_NAME] = github_url end
-    let(:github_url) { "gh.custom.org" }
-
-    its(:xdg_path) { should be_a_pathname_for File.expand_path "~/.cache/gist/auth_token.#{github_url}" }
-    its(:legacy_path) { should be_a_pathname_for File.expand_path "~/.gist.#{github_url}" }
-    its(:github_url_suffix) { should == ".#{github_url}" }
   end
 
   describe "auth token file location" do

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -55,6 +55,8 @@ describe Gist::AuthTokenFile do
     let(:xdg_path) { double }
     let(:legacy_path) { double }
     before do
+      subject.instance_variable_set(:@xdg_path, xdg_path)
+      subject.instance_variable_set(:@legacy_path, legacy_path)
       subject.stub(:xdg_path).and_return(xdg_path)
       subject.stub(:legacy_path).and_return(legacy_path)
     end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -66,8 +66,8 @@ describe Gist::AuthTokenFile do
       File.stub(:expand_path) {|f| f }
     end
 
-    its(:xdg_filename) { should == "~/.cache/gist/auth_token" }
-    its(:legacy_filename) { should == "~/.gist" }
+    its(:xdg_path) { should == "~/.cache/gist/auth_token" }
+    its(:legacy_path) { should == "~/.gist" }
     its(:github_url_suffix) { should == "" }
   end
 
@@ -78,14 +78,14 @@ describe Gist::AuthTokenFile do
     end
     let(:github_url) { "gh.custom.org" }
 
-    its(:xdg_filename) { should == "~/.cache/gist/auth_token.#{github_url}" }
-    its(:legacy_filename) { should == "~/.gist.#{github_url}" }
+    its(:xdg_path) { should == "~/.cache/gist/auth_token.#{github_url}" }
+    its(:legacy_path) { should == "~/.gist.#{github_url}" }
     its(:github_url_suffix) { should == ".#{github_url}" }
   end
 
   context "when XDG_CACHE_HOME/gist/auth_token exists" do
     before do
-      File.should_receive(:exist?).with(subject.xdg_filename).and_return(true)
+      File.should_receive(:exist?).with(subject.xdg_path).and_return(true)
     end
 
     it { should be_xdg }
@@ -93,12 +93,12 @@ describe Gist::AuthTokenFile do
 
   context "when XDG_CACHE_HOME/gist/auth_token doesn't exit" do
     before do
-      File.should_receive(:exist?).with(subject.xdg_filename).and_return(false)
+      File.should_receive(:exist?).with(subject.xdg_path).and_return(false)
     end
 
     context "when ~/.gist exists" do
       before do
-        File.should_receive(:exist?).with(subject.legacy_filename).and_return(true)
+        File.should_receive(:exist?).with(subject.legacy_path).and_return(true)
       end
 
       it { should_not be_xdg }
@@ -106,7 +106,7 @@ describe Gist::AuthTokenFile do
 
     context "when ~/.gist doesn't exist" do
       before do
-        File.should_receive(:exist?).with(subject.legacy_filename).and_return(false)
+        File.should_receive(:exist?).with(subject.legacy_path).and_return(false)
       end
 
       it { should be_xdg }

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -1,9 +1,3 @@
-RSpec::Matchers.define :be_a_pathname_for do |expected|
-  match do |actual|
-    actual.to_s == File.expand_path(expected)
-  end
-end
-
 describe Gist::AuthTokenFile do
   subject { Gist::AuthTokenFile }
 

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -6,30 +6,6 @@ describe Gist::AuthTokenFile do
     stub_const("Gist::XDG::CACHE_HOME_ENV_NAME", "STUBBED_XDG_CACHE_HOME")
   end
 
-  describe "::filename" do
-    let(:filename) { double() }
-
-    context "with default GITHUB_URL" do
-      it "is ~/.gist" do
-        File.should_receive(:expand_path).with("~/.gist").and_return(filename)
-        subject.filename.should be filename
-      end
-    end
-
-    context "with custom GITHUB_URL" do
-      before do
-        ENV[Gist::URL_ENV_NAME] = github_url
-      end
-      let(:github_url) { "gh.custom.org" }
-
-      it "is ~/.gist.{custom_github_url}" do
-        File.should_receive(:expand_path).with("~/.gist.#{github_url}").and_return(filename)
-        subject.filename.should be filename
-      end
-    end
-
-  end
-
   describe "::read" do
     let(:token) { "auth_token" }
 
@@ -89,6 +65,7 @@ describe Gist::AuthTokenFile do
     end
 
     it { should be_xdg }
+    its(:filename) { should == subject.xdg_path }
   end
 
   context "when XDG_CACHE_HOME/gist/auth_token doesn't exit" do
@@ -102,6 +79,7 @@ describe Gist::AuthTokenFile do
       end
 
       it { should_not be_xdg }
+      its(:filename) { should == subject.legacy_path }
     end
 
     context "when ~/.gist doesn't exist" do
@@ -110,6 +88,7 @@ describe Gist::AuthTokenFile do
       end
 
       it { should be_xdg }
+      its(:filename) { should == subject.xdg_path }
     end
   end
 

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -1,11 +1,9 @@
 describe Gist::AuthTokenFile do
-  subject { Gist::AuthTokenFile }
-
   before(:each) do
     stub_const("Gist::URL_ENV_NAME", "STUBBED_GITHUB_URL")
   end
 
-  describe "::read" do
+  describe "#read" do
     let(:token) { "auth_token" }
     let(:pathname) { double }
 
@@ -22,7 +20,7 @@ describe Gist::AuthTokenFile do
     end
   end
 
-  describe "::write" do
+  describe "#write" do
     let(:token) { double }
     let(:pathname) { double }
     let(:token_file) { double }

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -37,8 +37,8 @@ describe Gist::AuthTokenFile do
   context "with default GITHUB_URL" do
     before do ENV.delete Gist::URL_ENV_NAME end
 
-    its(:xdg_path) { should be_a_pathname_for "~/.cache/gist/auth_token" }
-    its(:legacy_path) { should be_a_pathname_for "~/.gist" }
+    its(:xdg_path) { should be_a_pathname_for File.expand_path "~/.cache/gist/auth_token" }
+    its(:legacy_path) { should be_a_pathname_for File.expand_path "~/.gist" }
     its(:github_url_suffix) { should == "" }
   end
 
@@ -46,43 +46,40 @@ describe Gist::AuthTokenFile do
     before do ENV[Gist::URL_ENV_NAME] = github_url end
     let(:github_url) { "gh.custom.org" }
 
-    its(:xdg_path) { should be_a_pathname_for "~/.cache/gist/auth_token.#{github_url}" }
-    its(:legacy_path) { should be_a_pathname_for "~/.gist.#{github_url}" }
+    its(:xdg_path) { should be_a_pathname_for File.expand_path "~/.cache/gist/auth_token.#{github_url}" }
+    its(:legacy_path) { should be_a_pathname_for File.expand_path "~/.gist.#{github_url}" }
     its(:github_url_suffix) { should == ".#{github_url}" }
   end
 
   describe "auth token file location" do
-    let(:xdg_path) { double }
-    let(:legacy_path) { double }
     before do
-      subject.instance_variable_set(:@xdg_path, xdg_path)
-      subject.instance_variable_set(:@legacy_path, legacy_path)
-      subject.stub(:xdg_path).and_return(xdg_path)
-      subject.stub(:legacy_path).and_return(legacy_path)
+      subject.xdg_path.stub(:exist?).and_return(xdg_tokens_exist)
+      subject.legacy_path.stub(:exist?).and_return(legacy_tokens_exist)
     end
 
-    context "when XDG_CACHE_HOME/gist/auth_token exists" do
-      before do xdg_path.stub(:exist?).and_return(true) end
+    context "when XDG_CACHE_HOME/gist/auth_token* exist" do
+      let(:xdg_tokens_exist) { true }
+      let(:legacy_tokens_exist) { "doesn't matter" }
 
       it { should be_xdg }
-      its(:pathname) { should == xdg_path }
+      its(:pathname) { should be_a_pathname_for subject.xdg_path }
     end
 
-    context "when XDG_CACHE_HOME/gist/auth_token doesn't exit" do
-      before do xdg_path.stub(:exist?).and_return(false) end
+    context "when XDG_CACHE_HOME/gist/auth_token* don't exist" do
+      let(:xdg_tokens_exist) { false }
 
-      context "when ~/.gist exists" do
-        before do legacy_path.stub(:exist?).and_return(true) end
+      context "when ~/.gist* exists" do
+        let(:legacy_tokens_exist) { true }
 
         it { should_not be_xdg }
-        its(:pathname) { should == legacy_path }
+        its(:pathname) { should be_a_pathname_for subject.legacy_path }
       end
 
-      context "when ~/.gist doesn't exist" do
-        before do legacy_path.stub(:exist?).and_return(false) end
+      context "when ~/.gist* don't exist" do
+        let(:legacy_tokens_exist) { false }
 
         it { should be_xdg }
-        its(:pathname) { should == xdg_path }
+        its(:pathname) { should be_a_pathname_for subject.xdg_path }
       end
     end
 

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -76,4 +76,32 @@ describe Gist::AuthTokenFile do
     its(:github_url_suffix) { should == ".#{github_url}" }
   end
 
+  describe "::xdg?" do
+    let(:cache_home) { "/cache/home" }
+
+    before do
+      ENV['XDG_CACHE_HOME'] = cache_home
+    end
+
+    it "checks for $XDG_CACHE_HOME/gist" do
+      File.should_receive(:exist?).with("#{cache_home}/gist")
+      subject.xdg?
+    end
+
+    context "when $XDG_CACHE_HOME/gist exists" do
+      before do
+        File.should_receive(:exist?).and_return(true)
+      end
+
+      it { should be_xdg }
+    end
+
+    context "when $XDG_CACHE_HOME/gist does not exist" do
+      before do
+        File.should_receive(:exist?).and_return(false)
+      end
+      it { should_not be_xdg }
+    end
+  end
+
 end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -26,7 +26,7 @@ describe Gist::AuthTokenFile do
     let(:token_file) { double() }
 
     before do
-      subject.stub(:filename) { filename }
+      subject.stub(:pathname) { filename }
     end
 
     it "writes token to file" do
@@ -65,7 +65,7 @@ describe Gist::AuthTokenFile do
     end
 
     it { should be_xdg }
-    its(:filename) { should == subject.xdg_path }
+    its(:pathname) { should == subject.xdg_path }
   end
 
   context "when XDG_CACHE_HOME/gist/auth_token doesn't exit" do
@@ -79,7 +79,7 @@ describe Gist::AuthTokenFile do
       end
 
       it { should_not be_xdg }
-      its(:filename) { should == subject.legacy_path }
+      its(:pathname) { should == subject.legacy_path }
     end
 
     context "when ~/.gist doesn't exist" do
@@ -88,7 +88,7 @@ describe Gist::AuthTokenFile do
       end
 
       it { should be_xdg }
-      its(:filename) { should == subject.xdg_path }
+      its(:pathname) { should == subject.xdg_path }
     end
   end
 

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -18,14 +18,23 @@ describe Gist::AuthTokenFile do
 
   describe "#write" do
     let(:token) { double }
-    let(:pathname) { double }
+    let(:pathname) { spy }
     let(:token_file) { double }
 
-    before do subject.stub(:pathname).and_return(pathname) end
+    before do
+      subject.stub(:pathname).and_return(pathname)
+      FileUtils.stub(:mkpath)
+    end
 
     it "writes token to file" do
       pathname.should_receive(:open).with('w', 0600).and_yield(token_file)
       token_file.should_receive(:write).with(token)
+      subject.write(token)
+    end
+
+    it "creates directories as needed" do
+      pathname.stub(:dirname).and_return("pathdir")
+      FileUtils.should_receive(:mkpath).with("pathdir")
       subject.write(token)
     end
   end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -13,27 +13,30 @@ describe Gist::AuthTokenFile do
 
   describe "::read" do
     let(:token) { "auth_token" }
+    let(:pathname) { double }
+
+    before do subject.stub(:pathname).and_return(pathname) end
 
     it "reads file contents" do
-      File.should_receive(:read).and_return(token)
+      pathname.should_receive(:read).and_return(token)
       subject.read.should eq token
     end
 
     it "chomps file contents" do
-      File.should_receive(:read).and_return(token + "\n")
+      pathname.should_receive(:read).and_return(token + "\n")
       subject.read.should eq token
     end
   end
 
   describe "::write" do
     let(:token) { double }
-    let(:filename) { double }
+    let(:pathname) { double }
     let(:token_file) { double }
 
-    before do subject.stub(:pathname) { filename } end
+    before do subject.stub(:pathname).and_return(pathname) end
 
     it "writes token to file" do
-      File.should_receive(:open).with(filename.to_s, 'w', 0600).and_yield(token_file)
+      pathname.should_receive(:open).with('w', 0600).and_yield(token_file)
       token_file.should_receive(:write).with(token)
       subject.write(token)
     end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -1,9 +1,14 @@
+RSpec::Matchers.define :be_a_pathname_for do |expected|
+  match do |actual|
+    actual.to_s == File.expand_path(expected)
+  end
+end
+
 describe Gist::AuthTokenFile do
   subject { Gist::AuthTokenFile }
 
   before(:each) do
     stub_const("Gist::URL_ENV_NAME", "STUBBED_GITHUB_URL")
-    stub_const("Gist::XDG::CACHE_HOME_ENV_NAME", "STUBBED_XDG_CACHE_HOME")
   end
 
   describe "::read" do
@@ -21,75 +26,68 @@ describe Gist::AuthTokenFile do
   end
 
   describe "::write" do
-    let(:token) { double() }
-    let(:filename) { double() }
-    let(:token_file) { double() }
+    let(:token) { double }
+    let(:filename) { double }
+    let(:token_file) { double }
 
-    before do
-      subject.stub(:pathname) { filename }
-    end
+    before do subject.stub(:pathname) { filename } end
 
     it "writes token to file" do
-      File.should_receive(:open).with(filename, 'w', 0600).and_yield(token_file)
+      File.should_receive(:open).with(filename.to_s, 'w', 0600).and_yield(token_file)
       token_file.should_receive(:write).with(token)
       subject.write(token)
     end
   end
 
   context "with default GITHUB_URL" do
-    before do
-      ENV.delete Gist::URL_ENV_NAME
-      File.stub(:expand_path) {|f| f }
-    end
+    before do ENV.delete Gist::URL_ENV_NAME end
 
-    its(:xdg_path) { should == "~/.cache/gist/auth_token" }
-    its(:legacy_path) { should == "~/.gist" }
+    its(:xdg_path) { should be_a_pathname_for "~/.cache/gist/auth_token" }
+    its(:legacy_path) { should be_a_pathname_for "~/.gist" }
     its(:github_url_suffix) { should == "" }
   end
 
   context "with custom GITHUB_URL" do
-    before do
-      ENV[Gist::URL_ENV_NAME] = github_url
-      File.stub(:expand_path) {|f| f }
-    end
+    before do ENV[Gist::URL_ENV_NAME] = github_url end
     let(:github_url) { "gh.custom.org" }
 
-    its(:xdg_path) { should == "~/.cache/gist/auth_token.#{github_url}" }
-    its(:legacy_path) { should == "~/.gist.#{github_url}" }
+    its(:xdg_path) { should be_a_pathname_for "~/.cache/gist/auth_token.#{github_url}" }
+    its(:legacy_path) { should be_a_pathname_for "~/.gist.#{github_url}" }
     its(:github_url_suffix) { should == ".#{github_url}" }
   end
 
-  context "when XDG_CACHE_HOME/gist/auth_token exists" do
+  describe "auth token file location" do
+    let(:xdg_path) { double }
+    let(:legacy_path) { double }
     before do
-      File.should_receive(:exist?).with(subject.xdg_path).and_return(true)
+      subject.stub(:xdg_path).and_return(xdg_path)
+      subject.stub(:legacy_path).and_return(legacy_path)
     end
 
-    it { should be_xdg }
-    its(:pathname) { should == subject.xdg_path }
-  end
-
-  context "when XDG_CACHE_HOME/gist/auth_token doesn't exit" do
-    before do
-      File.should_receive(:exist?).with(subject.xdg_path).and_return(false)
-    end
-
-    context "when ~/.gist exists" do
-      before do
-        File.should_receive(:exist?).with(subject.legacy_path).and_return(true)
-      end
-
-      it { should_not be_xdg }
-      its(:pathname) { should == subject.legacy_path }
-    end
-
-    context "when ~/.gist doesn't exist" do
-      before do
-        File.should_receive(:exist?).with(subject.legacy_path).and_return(false)
-      end
+    context "when XDG_CACHE_HOME/gist/auth_token exists" do
+      before do xdg_path.stub(:exist?).and_return(true) end
 
       it { should be_xdg }
-      its(:pathname) { should == subject.xdg_path }
+      its(:pathname) { should == xdg_path }
     end
-  end
 
+    context "when XDG_CACHE_HOME/gist/auth_token doesn't exit" do
+      before do xdg_path.stub(:exist?).and_return(false) end
+
+      context "when ~/.gist exists" do
+        before do legacy_path.stub(:exist?).and_return(true) end
+
+        it { should_not be_xdg }
+        its(:pathname) { should == legacy_path }
+      end
+
+      context "when ~/.gist doesn't exist" do
+        before do legacy_path.stub(:exist?).and_return(false) end
+
+        it { should be_xdg }
+        its(:pathname) { should == xdg_path }
+      end
+    end
+
+  end
 end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -58,4 +58,22 @@ describe Gist::AuthTokenFile do
       subject.write(token)
     end
   end
+
+  context "with default GITHUB_URL" do
+    before do
+      ENV.delete Gist::URL_ENV_NAME
+    end
+
+    its(:github_url_suffix) { should == "" }
+  end
+
+  context "with custom GITHUB_URL" do
+    before do
+      ENV[Gist::URL_ENV_NAME] = github_url
+    end
+    let(:github_url) { "gh.custom.org" }
+
+    its(:github_url_suffix) { should == ".#{github_url}" }
+  end
+
 end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -86,3 +86,25 @@ describe Gist::AuthTokenFile do
 
   end
 end
+
+describe Gist::AuthTokenPathname do
+  subject { Gist::AuthTokenPathname.new pathname }
+
+  describe "#exist?" do
+    let(:pathname) { "~/.gist" }
+
+    before do
+      Dir.should_receive(:glob).with(File.expand_path(pathname) + "*").and_return(globbed_files)
+    end
+
+    context "with any matching token files" do
+      let(:globbed_files) { [double] }
+      it { should exist }
+    end
+
+    context "without any matching token files" do
+      let(:globbed_files) { [] }
+      it { should_not exist }
+    end
+  end
+end

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -7,12 +7,12 @@ describe Gist::AuthTokenFile do
 
     it "reads file contents" do
       pathname.should_receive(:read).and_return(token)
-      subject.read.should eq token
+      subject.read.should == token
     end
 
     it "chomps file contents" do
       pathname.should_receive(:read).and_return(token + "\n")
-      subject.read.should eq token
+      subject.read.should == token
     end
   end
 
@@ -41,7 +41,7 @@ describe Gist::AuthTokenFile do
       let(:legacy_tokens_exist) { "doesn't matter" }
 
       it { should be_xdg }
-      its(:pathname) { should be_a_pathname_for subject.xdg_path }
+      its(:pathname) { should be_expanded_path_for subject.xdg_path }
     end
 
     context "when XDG_CACHE_HOME/gist/auth_token* don't exist" do
@@ -51,26 +51,22 @@ describe Gist::AuthTokenFile do
         let(:legacy_tokens_exist) { true }
 
         it { should_not be_xdg }
-        its(:pathname) { should be_a_pathname_for subject.legacy_path }
+        its(:pathname) { should be_expanded_path_for subject.legacy_path }
       end
 
       context "when ~/.gist* don't exist" do
         let(:legacy_tokens_exist) { false }
 
         it { should be_xdg }
-        its(:pathname) { should be_a_pathname_for subject.xdg_path }
+        its(:pathname) { should be_expanded_path_for subject.xdg_path }
       end
     end
-
   end
 end
 
 describe Gist::AuthTokenPathname do
-  before do
-    stub_const("Gist::URL_ENV_NAME", "STUBBED_GITHUB_URL")
-  end
-
   subject { Gist::AuthTokenPathname.new pathname }
+  before do stub_const("Gist::URL_ENV_NAME", "STUBBED_GITHUB_URL") end
   let(:pathname) { "/.gist" }
 
   its(:to_pathname) { should be_a Pathname }
@@ -92,8 +88,8 @@ describe Gist::AuthTokenPathname do
   context "with default GITHUB_URL" do
     before do ENV.delete Gist::URL_ENV_NAME end
 
-    its(:to_s) { should == File.expand_path(pathname) }
-    its(:to_pathname) { should be_a_pathname_for pathname }
+    its(:to_s) { should be_expanded_path_for pathname }
+    its(:to_pathname) { should be_expanded_path_for pathname }
     its(:github_url_suffix) { should == "" }
   end
 
@@ -102,9 +98,8 @@ describe Gist::AuthTokenPathname do
     let(:github_url) { "gh.custom.org" }
     let(:github_url_suffix) { "." + github_url }
 
-    its(:to_s) { should == File.expand_path(pathname+github_url_suffix) }
-    its(:to_pathname) { should be_a_pathname_for pathname+github_url_suffix }
+    its(:to_s) { should be_expanded_path_for pathname+github_url_suffix }
+    its(:to_pathname) { should be_expanded_path_for pathname+github_url_suffix }
     its(:github_url_suffix) { should == github_url_suffix }
   end
-
 end

--- a/spec/ghe_spec.rb
+++ b/spec/ghe_spec.rb
@@ -35,8 +35,8 @@ describe '...' do
       # stdin emulation
       $stdin = StringIO.new "#{MOCK_USER}\n#{MOCK_PASSWORD}\n"
 
-      # intercept for updating ~/.gist
-      File.stub(:open)
+      # intercept for updating auth_tokens
+      Gist::AuthTokenFile.any_instance.stub(:write)
     end
 
     after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ require 'gist'
 
 RSpec::Matchers.define :be_a_pathname_for do |expected|
   match do |actual|
-    actual.to_s == File.expand_path(expected)
+    actual.to_s == File.expand_path(expected.to_s)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,10 @@ end
 
 require 'webmock/rspec'
 require 'gist'
+
+RSpec::Matchers.define :be_a_pathname_for do |expected|
+  match do |actual|
+    actual.to_s == File.expand_path(expected)
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ end
 require 'webmock/rspec'
 require 'gist'
 
-RSpec::Matchers.define :be_a_pathname_for do |expected|
+RSpec::Matchers.define :be_expanded_path_for do |expected|
   match do |actual|
     actual.to_s == File.expand_path(expected.to_s)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'rspec/its'
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus

--- a/spec/xdg_spec.rb
+++ b/spec/xdg_spec.rb
@@ -16,4 +16,14 @@ describe Gist::XDG do
 
     its(:cache_home) { should == "~/.cache" }
   end
+
+  describe "::cache" do
+    before do
+      ENV['XDG_CACHE_HOME'] = "/cache_home"
+    end
+
+    it "should expand given path relative to CACHE_HOME" do
+      subject.cache("mydir").should == "/cache_home/mydir"
+    end
+  end
 end

--- a/spec/xdg_spec.rb
+++ b/spec/xdg_spec.rb
@@ -1,0 +1,19 @@
+describe Gist::XDG do
+  subject { Gist::XDG }
+
+  context "with $XDG_CACHE_HOME set" do
+    before do
+      ENV['XDG_CACHE_HOME'] = "some/cache/path"
+    end
+
+    its(:cache_home) { should == "some/cache/path" }
+  end
+
+  context "with $XDG_CACHE_HOME unset" do
+    before do
+      ENV.delete 'XDG_CACHE_HOME'
+    end
+
+    its(:cache_home) { should == "~/.cache" }
+  end
+end


### PR DESCRIPTION
Follow the XDG directory spec for storing authentication tokens.

closes #179 
alternate implementation to #158 

Decision tree:

| XDG token | ~ token | directory used |
| --- | --- | --- |
| does not exist | exists | ~ |
| exists | does not exist | XDG |
| exists | exists | XDG |
| does not exist | does not exist | XDG |

So for existing users with existing auth tokens in `~`, nothing will change. It will continue to use the token files from `~`. For users who wish to migrate to the XDG directories, the existing tokens would need to be moved/copied to the XDG directory (either `$XDG_CACHE_HOME/gist` or `~/.cache/gist`). For new users (or users without existing tokens), the XDG directory structure is used as the preferred location. The only weird edge case is for users who have tokens in _both_ `~` and XDG locations (for whatever weird reason). In that scenario, the XDG tokens are used.

<del>There is a wrinkle that still exists. Since the directory location for reading/writing branches off whether the specific token file exists (including the GITHUB_URL suffix), it is possible to end up with `~/.gist` and `~/.cache/gist/auth_token.somecorp.github.com` or vice versa. This is clearly not desirable.
So I have plans to change the decision tree to branch based on whether `$XDG_CACHE_HOME/gist` and `~/.gist*` exist. This way we'll be deciding based on the existence of the gist _directory_ under `$XDG_CACHE_HOME` as well as whether _any_ `.gist*` file exists in `~`; not a specific token file in particular. This will ensure that the multiple gist tokens are always stored together, whether they be in `~` or `$XDG_CACHE_HOME`.</del>

<ins>When determining whether tokens exist, potential GITHUB_URL suffixes are ignored. In this way, the same directory will be used for new tokens even if they differ by GITHUB_URL</ins>


Feedback?
