### PR TITLE
gist listing: add --number and --pages option

### DIFF
--- a/bin/gist
+++ b/bin/gist
@@ -111,8 +111,18 @@ Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL] [-P]
     options[:raw] = true
   end
 
-  opts.on("-l", "--list [USER]", "List all gists for user") do |user|
+  opts.on("-l", "--list [USER]", "List gists for user (all by default)") do |user|
     options[:list] = user
+  end
+
+  opts.on("--number [NUMBER]", OptionParser::DecimalInteger,
+          "Maximum number of gists (in conjuction with --list)") do |number|
+    options[:max_number] = number
+  end
+
+  opts.on("--pages [NUMBER]", OptionParser::DecimalInteger,
+          "Maximum number of pages (in conjuction with --list)") do |pages|
+    options[:max_pages] = pages
   end
 
   opts.on_tail("-h","--help", "Show this message.") do
@@ -145,11 +155,8 @@ begin
   options[:public] = Gist.should_be_public?(options)
 
   if options.key? :list
-    if options[:list]
-      Gist.list_all_gists(options[:list])
-    else
-      Gist.list_all_gists
-    end
+    user = options[:list] ? options[:list] : ""
+    Gist.list_all_gists(user, options)
     exit
   end
 


### PR DESCRIPTION
Listing all gists is slow when a user has a large collection. This patch adds two CLI options `--number` and `--pages` (as well as corresponding API options) to help limiting the number/pages of gists listed.

Updated API should be backwards compatible. List of changes in the API:

* New optional parameters to `list_all_gists`, `get_gist_pages` and
  `pretty_gist`;
* `pretty_gist` now returns the number of gists listed, instead of
  `nil`.

Usage example:

```
> ruby -Ilib bin/gist --list defunkt --number 5
https://gist.github.com/cda3a6a1d039398f09ee gistfile1.rb
https://gist.github.com/9077942
https://gist.github.com/4283721 pjax helpers for different frameworks
https://gist.github.com/4256043 namespace.coffee
https://gist.github.com/3910523
```