### PR TITLE
Fix typo introduced in 687c15a

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -188,7 +188,7 @@ module Gist
     if user == ""
       access_token = auth_token()
       if access_token.to_s != ''
-        url << "/gists?per_page=100&taccess_token=" << CGI.escape(access_token)
+        url << "/gists?per_page=100&access_token=" << CGI.escape(access_token)
         get_gist_pages(url)
       else
         raise Error, "Not authenticated. Use 'gist --login' to login or 'gist -l username' to view public gists."


### PR DESCRIPTION
`taccess_token` => `access_token`.

The wrong query string is preventing authenticated listing, so `--list`
without argument is wrongly listing recent gists on the entire
gist.github.com (instead of listing gists of the authenticated user) in
v4.4.1.