### PR TITLE
Add --delete option

### DIFF
--- a/bin/gist
+++ b/bin/gist
@@ -123,6 +123,10 @@ Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL] [-P]
     options[:read] = id
   end
 
+  opts.on("--delete [ URL | ID ]", "Delete a gist") do |id|
+    options[:delete] = id
+  end
+
   opts.on_tail("-h","--help", "Show this message.") do
     puts opts
     exit
@@ -164,6 +168,11 @@ begin
   if options.key? :read
     file_name = ARGV.first
     Gist.read_gist(options[:read], file_name)
+    exit
+  end
+
+  if options.key? :delete
+    Gist.delete_gist(options[:delete])
     exit
   end
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -223,6 +223,27 @@ module Gist
     end
   end
 
+  def delete_gist(id)
+    id = id.split("/").last
+    url = "#{base_path}/gists/#{id}"
+
+    access_token = auth_token()
+    if access_token.to_s != ''
+      url << "?access_token=" << CGI.escape(access_token)
+
+      request = Net::HTTP::Delete.new(url)
+      response = http(api_url, request)
+    else
+      raise Error, "Not authenticated. Use 'gist --login' to login."
+    end
+
+    if response.code == '204'
+      puts "Deleted!"
+    else
+      raise Error, "Gist with id of #{id} does not exist."
+    end
+  end
+
   def get_gist_pages(url)
 
     request = Net::HTTP::Get.new(url)


### PR DESCRIPTION
Simple feature requested in #211.

You can delete the gist with the ID or URL using `gist --delete [ ID | URL ]` and you must be logged in.
