### PR TITLE
Environment variable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-gist(1) -- upload code to https://gist.github.com
+gist -- upload code to https://gist.github.com
 =================================================
 
 ## Synopsis
 
 The gist gem provides a `gist` command that you can use from your terminal to
 upload content to https://gist.github.com/.
+
+## Why the fork?
+
+This fork will use the environment variable GITHUB_AUTH_TOKEN in addition to the ~/.gist file.
+
+Also, usage documentation has been tweaked for clarity.
 
 ## Installation
 

--- a/build/gist
+++ b/build/gist
@@ -1897,7 +1897,7 @@ Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL] [-P]
     options[:shorten] = shorten
   end
 
-  opts.on("-u", "--update [ URL | ID ]", "Update an existing gist.") do |update|
+  opts.on("-u", "--update GIST_ID FILE_NAME", "Update an existing gist.") do |update|
     options[:update] = update
   end
 

--- a/gist.gemspec
+++ b/gist.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.executables << 'gist'
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'ronn'
-  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'rake', '~> 0'
+  s.add_development_dependency 'ronn', '~> 0'
+  s.add_development_dependency 'webmock', '~> 0'
   s.add_development_dependency 'rspec', '>3'
 end

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -12,7 +12,7 @@ end
 module Gist
   extend self
 
-  VERSION = '4.4.3'
+  VERSION = '4.4.4'
 
   # A list of clipboard commands with copy and paste support.
   CLIPBOARD_COMMANDS = {

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -59,13 +59,17 @@ module Gist
         f.write token
       end
     end
+
+    def self.read_token_or_fetch_from_env
+      ENV['GITHUB_AUTH_TOKEN'] || self.read rescue nil
+    end
   end
 
   # auth token for authentication
   #
   # @return [String] string value of access token or `nil`, if not found
   def auth_token
-    @token ||= AuthTokenFile.read rescue nil
+    @token ||= read_token_or_fetch_from_env
   end
 
   # Upload a gist to https://gist.github.com

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -12,7 +12,7 @@ end
 module Gist
   extend self
 
-  VERSION = '4.4.2'
+  VERSION = '4.4.3'
 
   # A list of clipboard commands with copy and paste support.
   CLIPBOARD_COMMANDS = {
@@ -69,7 +69,7 @@ module Gist
   #
   # @return [String] string value of access token or `nil`, if not found
   def auth_token
-    @token ||= read_token_or_fetch_from_env
+    @token ||= AuthTokenFile.read_token_or_fetch_from_env
   end
 
   # Upload a gist to https://gist.github.com

--- a/spec/gist_spec.rb
+++ b/spec/gist_spec.rb
@@ -18,6 +18,10 @@ describe Gist do
     it "should return true by default" do
       Gist.should_be_public?.should be_truthy
     end
+
+    it 'should pickup auth_token if set in env' do
+
+    end
   end
 
 end


### PR DESCRIPTION
Hello, I made a tiny tweak to my fork that enables me to use the OAuth token in an environment variable rather than a file. That way I don't accidentally commit the token and can centralize all my tokens to a single file that is ignored.