### PR TITLE
Read from environment variable GITHUB_AUTH_TOKEN if set.

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -59,13 +59,17 @@ module Gist
         f.write token
       end
     end
+
+    def self.read_token_or_fetch_from_env
+      ENV['GITHUB_AUTH_TOKEN'] || self.read rescue nil
+    end
   end
 
   # auth token for authentication
   #
   # @return [String] string value of access token or `nil`, if not found
   def auth_token
-    @token ||= AuthTokenFile.read rescue nil
+    @token ||= AuthTokenFile.read_token_or_fetch_from_env
   end
 
   # Upload a gist to https://gist.github.com

--- a/spec/auth_token_file_spec.rb
+++ b/spec/auth_token_file_spec.rb
@@ -31,6 +31,7 @@ describe Gist::AuthTokenFile do
 
   describe "::read" do
     let(:token) { "auth_token" }
+    let(:env_variable_name) { "GITHUB_AUTH_TOKEN" }
 
     it "reads file contents" do
       File.should_receive(:read).and_return(token)
@@ -40,6 +41,13 @@ describe Gist::AuthTokenFile do
     it "chomps file contents" do
       File.should_receive(:read).and_return(token + "\n")
       subject.read.should eq token
+    end
+
+    it 'should pickup auth_token if set in environment variable' do
+      cached_env_variable = ENV[env_variable_name]
+      ENV[env_variable_name] = "auth_token"
+      subject.read_token_or_fetch_from_env.should eq token
+      ENV[env_variable_name] = cached_env_variable
     end
   end
 


### PR DESCRIPTION
This prevents the need for another token file.
