### PR TITLE
Update the tests for the shorten command

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -268,7 +268,7 @@ module Gist
     response = http(GIT_IO_URL, request)
     case response.code
     when "200"
-      URI.join(GIT_IO_URL, response.body)
+      URI.join(GIT_IO_URL, response.body).to_s
     when "201"
       response['Location']
     else

--- a/spec/shorten_spec.rb
+++ b/spec/shorten_spec.rb
@@ -1,11 +1,15 @@
 describe '...' do
   before do
     stub_request(:post, /api\.github.com\/gists/).to_return(:body => '{"html_url": "http://github.com/"}')
-    stub_request(:post, "http://git.io/").to_return(:status => 201, :headers => { 'Location' => 'http://git.io/XXXXXX' })
   end
 
-  it "should return a shortened version of the URL" do
-    Gist.gist("Test gist", :output => :short_url, :anonymous => true).should == "http://git.io/XXXXXX"
+  it "should return a shortened version of the URL when response is 200" do
+    stub_request(:post, "https://git.io/create").to_return(:status => 200, :body => 'XXXXXX')
+    Gist.gist("Test gist", :output => :short_url, :anonymous => true).should == "https://git.io/XXXXXX"
+  end
+
+  it "should return a shortened version of the URL when response is 201" do
+    stub_request(:post, "https://git.io/create").to_return(:status => 201, :headers => { 'Location' => 'https://git.io/XXXXXX' })
+    Gist.gist("Test gist", :output => :short_url, :anonymous => true).should == "https://git.io/XXXXXX"
   end
 end
-


### PR DESCRIPTION
1. Retain a test for the older 201 response but use https.
2. Add a test for the 200 response that git.io currently returns.

Updates: https://github.com/defunkt/gist/pull/240