### PR TITLE
Print GitHub tokens URL on OAuth completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ an OAuth2 token (with the "gist" permission).
     GitHub username: ConradIrwin
     GitHub password:
     2-factor auth code:
-    Success! https://github.com/settings/applications
+    Success! https://github.com/settings/tokens
 
 This token is stored in `~/.gist` and used for all future gisting. If you need to
-you can revoke it from https://github.com/settings/applications, or just delete the
+you can revoke it from https://github.com/settings/tokens, or just delete the
 file.  If you need to store tokens for both github.com and a Github Enterprise instance 
 you can save your Github Enterprise token in `~/.gist.github.example.com` where 
 "github.example.com" is the URL for your Github Enterprise instance.

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -341,7 +341,7 @@ module Gist
 
       if Net::HTTPCreated === response
         AuthTokenFile.write JSON.parse(response.body)['token']
-        puts "Success! #{ENV[URL_ENV_NAME] || "https://github.com/"}settings/applications"
+        puts "Success! #{ENV[URL_ENV_NAME] || "https://github.com/"}settings/tokens"
         return
       elsif Net::HTTPUnauthorized === response
         puts "Error: #{JSON.parse(response.body)['message']}"


### PR DESCRIPTION
Replace https://github.com/settings/applications with https://github.com/settings/tokens

Suggested-By: https://github.com/starius
Completes: https://github.com/defunkt/gist/issues/225