### PR TITLE
Attempt to fetch oauth token from git credential

### DIFF
--- a/build/gist
+++ b/build/gist
@@ -1367,11 +1367,50 @@ module Gist
     end
   end
 
+  module AuthTokenGitCredential
+    def self.uri
+      if ENV.key?(URL_ENV_NAME)
+        URI.parse(ENV[URL_ENV_NAME])
+      else
+        GITHUB_API_URL
+      end
+    end
+
+    def self.helpers
+      IO.popen(["git", "config", "--get-all", "credential.helper"], &:read).split.uniq
+    end
+
+    def self.read
+      helpers.each do |helper|
+        begin
+          IO.popen(["git", "credential-#{helper}", "get"], "r+") do |io|
+            io.puts "protocol=#{uri.scheme}"
+            io.puts "hostname=#{uri.host}"
+            io.puts "username=#{uri.user}" if uri.user
+            io.puts
+
+            until io.eof?
+              line = io.readline.chomp
+              next if line.empty?
+
+              key, value = line.split("=", 2)
+              return value if key == "password"
+            end
+          end
+        rescue
+          # Swallow, try next helper
+        end
+      end
+
+      return nil
+    end
+  end
+
   # auth token for authentication
   #
   # @return [String] string value of access token or `nil`, if not found
   def auth_token
-    @token ||= AuthTokenFile.read rescue nil
+    @token ||= AuthTokenFile.read rescue AuthTokenGitCredential.read rescue nil
   end
 
   # Upload a gist to https://gist.github.com


### PR DESCRIPTION
If we use a git credential helper [like osxkeychain](https://help.github.com/articles/caching-your-github-password-in-git/) with a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#using-a-token-on-the-command-line) for [cloning our repositories via HTTPS](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended) then we already have a token for reading and writing gists stored securely using git, so maybe we should try using it. It's nice to avoid putting plaintext secrets on our filesystem and avoid polluting ENV with secrets.