### PR TITLE
add --skip-empty to skip gisting empty files

### DIFF
--- a/bin/gist
+++ b/bin/gist
@@ -203,7 +203,8 @@ begin
         end
     end
 
-    puts Gist.multi_gist(files, options)
+    output = Gist.multi_gist(files, options)
+    puts output if output
   end
 
 rescue Gist::Error => e

--- a/bin/gist
+++ b/bin/gist
@@ -47,7 +47,11 @@ Instead of creating a new gist, you can update an existing one by passing its ID
 or URL with "-u". For this to work, you must be logged in, and have created the
 original gist with the same GitHub account.
 
-Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL] [-P] [-f NAME|-t EXT]* FILE*
+If you want to skip empty files, use the --skip-empty flag. If all files are
+empty no gist will be created.
+
+Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL]
+                          [--skip-empty] [-P] [-f NAME|-t EXT]* FILE*
        #{executable_name} --login
        #{executable_name} [-l|-r]
 
@@ -106,6 +110,10 @@ Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL] [-P]
   end
 
   opts.on("--no-open")
+
+  opts.on("--skip-empty", "Skip gisting empty files") do
+    options[:skip_empty] = true
+  end
 
   opts.on("-P", "--paste", "Paste from the clipboard to gist") do
     options[:paste] = true

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -118,7 +118,7 @@ module Gist
       end
     end
 
-    raise "All files were empty. No gist created." if json[:files].empty? && options[:skip_empty]
+    return if json[:files].empty? && options[:skip_empty]
 
     existing_gist = options[:update].to_s.split("/").last
     if options[:anonymous]

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -92,6 +92,7 @@ module Gist
   # @option options [String] :update  the URL or id of a gist to update
   # @option options [Boolean] :copy  (false) Copy resulting URL to clipboard, if successful.
   # @option options [Boolean] :open  (false) Open the resulting URL in a browser.
+  # @option options [Boolean] :skip_empty (false) Skip gisting empty files.
   # @option options [Symbol] :output (:all) The type of return value you'd like:
   #   :html_url gives a String containing the url to the gist in a browser
   #   :short_url gives a String contianing a  git.io url that redirects to html_url
@@ -110,9 +111,14 @@ module Gist
     json[:files] = {}
 
     files.each_pair do |(name, content)|
-      raise "Cannot gist empty files" if content.to_s.strip == ""
-      json[:files][File.basename(name)] = {:content => content}
+      if content.to_s.strip == ""
+        raise "Cannot gist empty files" unless options[:skip_empty]
+      else
+        json[:files][File.basename(name)] = {:content => content}
+      end
     end
+
+    raise "All files were empty. No gist created." if json[:files].empty? && options[:skip_empty]
 
     existing_gist = options[:update].to_s.split("/").last
     if options[:anonymous]


### PR DESCRIPTION
fixes #208

Option --skip-empty will skip any zero length files passes to gist. If
all files are empty no gist will be created at all.

test plan:
```
  - create two empty files 'empty1' and 'empty2'.
  - create a third file with some content 'content1'.

  % bin/gist empty1 empty2 content1
  # should return error about an empty file

  % bin/gist --skip-empty empty1 empty2 content1
  # should create gist with single file 'content1'

  % bin/gist --skip-empty empty1 empty2
  # should return error/notice about all files empty no gist created

  % date | bin/gist
  # should create gist with date string
```