### PR TITLE
Remove anonymous support due to deprecation.

### DIFF
--- a/bin/gist
+++ b/bin/gist
@@ -148,6 +148,12 @@ Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL]
 end.parse!
 
 begin
+  if Gist.auth_token.nil?
+    puts 'Please log in with `gist --login`. ' \
+      '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+    exit(1)
+  end
+
   options[:output] = if options[:embed] && options[:shorten]
                        raise Gist::Error, "--embed does not make sense with --shorten"
                      elsif options[:embed]

--- a/bin/gist
+++ b/bin/gist
@@ -24,15 +24,11 @@ specified STDIN will be read. The default filename for STDIN is "a.rb", and all
 filenames can be overridden by repeating the "-f" flag. The most useful reason
 to do this is to change the syntax highlighting.
 
-If you'd like your gists to be associated with your GitHub account, so that you
-can edit them and find them in future, first use `gist --login` to obtain an
-Oauth2 access token. This is stored and used by gist in the future.
+All gists must to be associated with a GitHub account, so you will need to login with
+`gist --login` to obtain an Oauth2 access token. This is stored and used by gist in the future.
 
 Private gists do not have guessable URLs and can be created with "-p", you can
 also set the description at the top of the gist by passing "-d".
-
-Anonymous gists are not associated with your GitHub account, they can be created
-with "-a" even after you have used "gist --login".
 
 If you would like to shorten the resulting gist URL, use the -s flag. This will
 use GitHub's URL shortener, git.io. You can also use -R to get the link to the
@@ -50,7 +46,7 @@ original gist with the same GitHub account.
 If you want to skip empty files, use the --skip-empty flag. If all files are
 empty no gist will be created.
 
-Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL]
+Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-u URL]
                           [--skip-empty] [-P] [-f NAME|-t EXT]* FILE*
        #{executable_name} --login
        #{executable_name} [-l|-r]
@@ -90,10 +86,6 @@ Usage: #{executable_name} [-o|-c|-e] [-p] [-s] [-R] [-d DESC] [-a] [-u URL]
 
   opts.on("-u", "--update [ URL | ID ]", "Update an existing gist.") do |update|
     options[:update] = update
-  end
-
-  opts.on("-a", "--anonymous", "Create an anonymous gist.") do
-    options[:anonymous] = true
   end
 
   opts.on("-c", "--copy", "Copy the resulting URL to the clipboard") do

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -127,7 +127,8 @@ module Gist
 
     existing_gist = options[:update].to_s.split("/").last
     if options[:anonymous]
-      access_token = nil
+      raise 'Anonymous gist support has been removed by Github. ' \
+        'See: https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/'
     else
       access_token = (options[:access_token] || auth_token())
     end

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -108,6 +108,13 @@ module Gist
   #
   # @see http://developer.github.com/v3/gists/
   def multi_gist(files, options={})
+    if options[:anonymous]
+      raise 'Anonymous gists are no longer supported. Please log in with `gist --login`. ' \
+        '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+    else
+      access_token = (options[:access_token] || auth_token())
+    end
+
     json = {}
 
     json[:description] = options[:description] if options[:description]
@@ -126,12 +133,6 @@ module Gist
     return if json[:files].empty? && options[:skip_empty]
 
     existing_gist = options[:update].to_s.split("/").last
-    if options[:anonymous]
-      raise 'Anonymous gist support has been removed by Github. ' \
-        'See: https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/'
-    else
-      access_token = (options[:access_token] || auth_token())
-    end
 
     url = "#{base_path}/gists"
     url << "/" << CGI.escape(existing_gist) if existing_gist.to_s != ''

--- a/spec/rawify_spec.rb
+++ b/spec/rawify_spec.rb
@@ -6,7 +6,16 @@ describe '...' do
   end
 
   it "should return the raw file url" do
-    Gist.gist("Test gist", :output => :raw_url, :anonymous => true).should == "https://gist.github.com/anonymous/XXXXXX/raw"
+    Gist.gist("Test gist", :output => :raw_url, :anonymous => false).should == "https://gist.github.com/anonymous/XXXXXX/raw"
+  end
+
+  it 'should raise an error when trying to do operations without being logged in' do
+    error_msg = 'Anonymous gist support has been removed by Github. ' \
+      'See: https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/'
+
+    expect do
+      Gist.gist("Test gist", output: :raw_url, anonymous: true)
+    end.to raise_error(StandardError, error_msg)
   end
 end
 

--- a/spec/rawify_spec.rb
+++ b/spec/rawify_spec.rb
@@ -10,8 +10,8 @@ describe '...' do
   end
 
   it 'should raise an error when trying to do operations without being logged in' do
-    error_msg = 'Anonymous gist support has been removed by Github. ' \
-      'See: https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/'
+    error_msg = 'Anonymous gists are no longer supported. Please log in with `gist --login`. ' \
+      '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
 
     expect do
       Gist.gist("Test gist", output: :raw_url, anonymous: true)

--- a/spec/shorten_spec.rb
+++ b/spec/shorten_spec.rb
@@ -14,8 +14,8 @@ describe '...' do
   end
 
   it 'should raise an error when trying to get short urls without being logged in' do
-    error_msg = 'Anonymous gist support has been removed by Github. ' \
-      'See: https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/'
+    error_msg = 'Anonymous gists are no longer supported. Please log in with `gist --login`. ' \
+      '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
 
     expect do
       Gist.gist("Test gist", output: :short_url, anonymous: true)

--- a/spec/shorten_spec.rb
+++ b/spec/shorten_spec.rb
@@ -5,11 +5,20 @@ describe '...' do
 
   it "should return a shortened version of the URL when response is 200" do
     stub_request(:post, "https://git.io/create").to_return(:status => 200, :body => 'XXXXXX')
-    Gist.gist("Test gist", :output => :short_url, :anonymous => true).should == "https://git.io/XXXXXX"
+    Gist.gist("Test gist", :output => :short_url, anonymous: false).should == "https://git.io/XXXXXX"
   end
 
   it "should return a shortened version of the URL when response is 201" do
     stub_request(:post, "https://git.io/create").to_return(:status => 201, :headers => { 'Location' => 'https://git.io/XXXXXX' })
-    Gist.gist("Test gist", :output => :short_url, :anonymous => true).should == "https://git.io/XXXXXX"
+    Gist.gist("Test gist", :output => :short_url, anonymous: false).should == "https://git.io/XXXXXX"
+  end
+
+  it 'should raise an error when trying to get short urls without being logged in' do
+    error_msg = 'Anonymous gist support has been removed by Github. ' \
+      'See: https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/'
+
+    expect do
+      Gist.gist("Test gist", output: :short_url, anonymous: true)
+    end.to raise_error(StandardError, error_msg)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
     mocks.syntax = :should
   end
   config.expect_with :rspec do |expectations|
-    expectations.syntax = :should
+    expectations.syntax = [:should, :expect]
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/defunkt/gist/issues/275

This change is needed due to the deprecation warning/removal made by Github on the gist tool. See https://blog.github.com/2018-02-18-deprecation-notice-removing-anonymous-gist-creation/ for more info.

* [x] Move this check to the start so that if you do gist --anonymous it immediately fails without waiting for you to type a gist.
* [x] Also handle the case where the user has not yet logged in (You can test this by removing the file ~/.gist)
* [x] Remove the --anonymous option from the documentation.