### PR TITLE
Fix capitalization of GitHub and OAuth in messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ with gist. It doesn't store your username and password, it just uses them to get
 an OAuth2 token (with the "gist" permission).
 
     gist --login
-    Obtaining OAuth2 access_token from github.
+    Obtaining OAuth2 access_token from GitHub.
     GitHub username: ConradIrwin
     GitHub password:
     2-factor auth code:
@@ -101,7 +101,7 @@ file.
 #### Password-less login
 
 If you have a complicated authorization requirement you can manually create a
-token file by pasting a Github token with only the `gist` permission into a
+token file by pasting a GitHub token with only the `gist` permission into a
 file called `~/.gist`. You can create one from https://github.com/settings/tokens
 
 This file should contain only the token (~40 hex characters), and to make it
@@ -119,7 +119,7 @@ you need to export the `GITHUB_URL` environment variable (usually done in your `
     export GITHUB_URL=http://github.internal.example.com/
 
 Once you've done this and restarted your terminal (or run `source ~/.bashrc`), gist will
-automatically use github enterprise instead of the public github.com
+automatically use GitHub Enterprise instead of the public github.com
 
 Your token for GitHub Enterprise will be stored in `.gist.<protocol>.<server.name>[.<port>]` (e.g.
 `~/.gist.http.github.internal.example.com` for the GITHUB_URL example above) instead of `~/.gist`.

--- a/bin/gist
+++ b/bin/gist
@@ -25,7 +25,7 @@ filenames can be overridden by repeating the "-f" flag. The most useful reason
 to do this is to change the syntax highlighting.
 
 All gists must to be associated with a GitHub account, so you will need to login with
-`gist --login` to obtain an Oauth2 access token. This is stored and used by gist in the future.
+`gist --login` to obtain an OAuth2 access token. This is stored and used by gist in the future.
 
 Private gists do not have guessable URLs and can be created with "-p", you can
 also set the description at the top of the gist by passing "-d".
@@ -142,7 +142,7 @@ end.parse!
 begin
   if Gist.auth_token.nil?
     puts 'Please log in with `gist --login`. ' \
-      '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+      '(GitHub now requires credentials to gist https://bit.ly/2GBBxKw)'
     exit(1)
   end
 

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -110,7 +110,7 @@ module Gist
   def multi_gist(files, options={})
     if options[:anonymous]
       raise 'Anonymous gists are no longer supported. Please log in with `gist --login`. ' \
-        '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+        '(GitHub now requires credentials to gist https://bit.ly/2GBBxKw)'
     else
       access_token = (options[:access_token] || auth_token())
     end
@@ -346,7 +346,7 @@ module Gist
   # @option credentials [String] :password
   # @see http://developer.github.com/v3/oauth/
   def login!(credentials={})
-    puts "Obtaining OAuth2 access_token from github."
+    puts "Obtaining OAuth2 access_token from GitHub."
     loop do
       print "GitHub username: "
       username = credentials[:username] || $stdin.gets.strip

--- a/spec/rawify_spec.rb
+++ b/spec/rawify_spec.rb
@@ -11,7 +11,7 @@ describe '...' do
 
   it 'should raise an error when trying to do operations without being logged in' do
     error_msg = 'Anonymous gists are no longer supported. Please log in with `gist --login`. ' \
-      '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+      '(GitHub now requires credentials to gist https://bit.ly/2GBBxKw)'
 
     expect do
       Gist.gist("Test gist", output: :raw_url, anonymous: true)

--- a/spec/shorten_spec.rb
+++ b/spec/shorten_spec.rb
@@ -15,7 +15,7 @@ describe '...' do
 
   it 'should raise an error when trying to get short urls without being logged in' do
     error_msg = 'Anonymous gists are no longer supported. Please log in with `gist --login`. ' \
-      '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+      '(GitHub now requires credentials to gist https://bit.ly/2GBBxKw)'
 
     expect do
       Gist.gist("Test gist", output: :short_url, anonymous: true)


### PR DESCRIPTION
Just a few capitalization fixes for "GitHub" and "OAuth2" (along with test updates).