### PR TITLE
README update: Use umask when creating token file

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ token file by pasting a GitHub token with only the `gist` permission into a
 file called `~/.gist`. You can create one from https://github.com/settings/tokens
 
 This file should contain only the token (~40 hex characters), and to make it
-easier to edit, can optionally have a final newline (\n or \r\n).
+easier to edit, can optionally have a final newline (`\n` or `\r\n`).
 
 For example, one way to create this file would be to run:
 
-    echo MY_SECRET_TOKEN > ~/.gist
+    (umask 0077 && echo MY_SECRET_TOKEN > ~/.gist)
+
+The `umask` ensures that the file is only accessible from your user account.
 
 ### GitHub Enterprise
 


### PR DESCRIPTION
The originally suggested command in the README for manually setting up the `~/.gist` token file does not ensure that the correct file permissions are set on the file, which may expose the token to other user accounts on the system.

I'm changing the documentation to instead suggest running `umask 0077` before creating the file to ensure that no other user accounts on the system will have access to it. In addition, by putting the entire command in parentheses, the command is executed within a subshell so that the umask is only set temporarily for the purposes of creating the file:

```sh
(umask 0077 && echo MY_SECRET_TOKEN > ~/.gist)
```