### PR TITLE
Supply access token through Authorization header

### DIFF
--- a/build/gist
+++ b/build/gist
@@ -1416,7 +1416,7 @@ module Gist
   def multi_gist(files, options={})
     if options[:anonymous]
       raise 'Anonymous gists are no longer supported. Please log in with `gist --login`. ' \
-        '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+        '(GitHub now requires credentials to gist https://bit.ly/2GBBxKw)'
     else
       access_token = (options[:access_token] || auth_token())
     end
@@ -1442,9 +1442,9 @@ module Gist
 
     url = "#{base_path}/gists"
     url << "/" << CGI.escape(existing_gist) if existing_gist.to_s != ''
-    url << "?access_token=" << CGI.escape(access_token) if access_token.to_s != ''
 
     request = Net::HTTP::Post.new(url)
+    request['Authorization'] = "token #{access_token}" if access_token.to_s != ''
     request.body = JSON.dump(json)
     request.content_type = 'application/json'
 
@@ -1480,9 +1480,10 @@ module Gist
     if user == ""
       access_token = auth_token()
       if access_token.to_s != ''
-        url << "/gists?access_token=" << CGI.escape(access_token)
+        url << "/gists"
 
         request = Net::HTTP::Get.new(url)
+        request['Authorization'] = "token #{access_token}"
         response = http(api_url, request)
 
         pretty_gist(response)
@@ -1507,8 +1508,8 @@ module Gist
     if user == ""
       access_token = auth_token()
       if access_token.to_s != ''
-        url << "/gists?per_page=100&access_token=" << CGI.escape(access_token)
-        get_gist_pages(url)
+        url << "/gists?per_page=100"
+        get_gist_pages(url, access_token)
       else
         raise Error, "Not authenticated. Use 'gist --login' to login or 'gist -l username' to view public gists."
       end
@@ -1524,11 +1525,9 @@ module Gist
     url = "#{base_path}/gists/#{id}"
 
     access_token = auth_token()
-    if access_token.to_s != ''
-      url << "?access_token=" << CGI.escape(access_token)
-    end
 
     request = Net::HTTP::Get.new(url)
+    request['Authorization'] = "token #{access_token}" if access_token.to_s != ''
     response = http(api_url, request)
 
     if response.code == '200'
@@ -1554,9 +1553,8 @@ module Gist
 
     access_token = auth_token()
     if access_token.to_s != ''
-      url << "?access_token=" << CGI.escape(access_token)
-
       request = Net::HTTP::Delete.new(url)
+      request["Authorization"] = "token #{access_token}"
       response = http(api_url, request)
     else
       raise Error, "Not authenticated. Use 'gist --login' to login."
@@ -1569,9 +1567,10 @@ module Gist
     end
   end
 
-  def get_gist_pages(url)
+  def get_gist_pages(url, access_token = "")
 
     request = Net::HTTP::Get.new(url)
+    request['Authorization'] = "token #{access_token}" if access_token.to_s != ''
     response = http(api_url, request)
     pretty_gist(response)
 
@@ -1579,7 +1578,7 @@ module Gist
 
     if link_header
       links = Hash[ link_header.gsub(/(<|>|")/, "").split(',').map { |link| link.split('; rel=') } ].invert
-      get_gist_pages(links['next']) if links['next']
+      get_gist_pages(links['next'], access_token) if links['next']
     end
 
   end
@@ -1652,7 +1651,7 @@ module Gist
   # @option credentials [String] :password
   # @see http://developer.github.com/v3/oauth/
   def login!(credentials={})
-    puts "Obtaining OAuth2 access_token from github."
+    puts "Obtaining OAuth2 access_token from GitHub."
     loop do
       print "GitHub username: "
       username = credentials[:username] || $stdin.gets.strip
@@ -1906,7 +1905,7 @@ filenames can be overridden by repeating the "-f" flag. The most useful reason
 to do this is to change the syntax highlighting.
 
 All gists must to be associated with a GitHub account, so you will need to login with
-`gist --login` to obtain an Oauth2 access token. This is stored and used by gist in the future.
+`gist --login` to obtain an OAuth2 access token. This is stored and used by gist in the future.
 
 Private gists do not have guessable URLs and can be created with "-p", you can
 also set the description at the top of the gist by passing "-d".
@@ -2023,7 +2022,7 @@ end.parse!
 begin
   if Gist.auth_token.nil?
     puts 'Please log in with `gist --login`. ' \
-      '(Github now requires credentials to gist https://bit.ly/2GBBxKw)'
+      '(GitHub now requires credentials to gist https://bit.ly/2GBBxKw)'
     exit(1)
   end
 


### PR DESCRIPTION
Instead of through query parameter, since that method is being actively deprecated.

* https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters
* https://developer.github.com/v3/#oauth2-token-sent-in-a-header