### PR TITLE
Allow hyphens in GITHUB_URL

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -44,7 +44,7 @@ module Gist
   module AuthTokenFile
     def self.filename
       if ENV.key?(URL_ENV_NAME)
-        File.expand_path "~/.gist.#{ENV[URL_ENV_NAME].gsub(/:/, '.').gsub(/[^a-z0-9.]/, '')}"
+        File.expand_path "~/.gist.#{ENV[URL_ENV_NAME].gsub(/:/, '.').gsub(/[^a-z0-9.-]/, '')}"
       else
         File.expand_path "~/.gist"
       end


### PR DESCRIPTION
The parsing of the `GITHUB_URL` should support hyphens in host names
to comply with https://tools.ietf.org/html/rfc952 .

Otherwise `gist` will fail to find the corresponding `.gist` token
file if the server contains a hyphen. For example,
`https://github.my-corp.com/`.

Signed-off-by: Lucas Magasweran <lrm@linux.com>