### PR TITLE
Always pass the auth token when listing all gists

### DIFF
--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -200,19 +200,12 @@ module Gist
     url = "#{base_path}"
 
     if user == ""
-      access_token = auth_token()
-      if access_token.to_s != ''
-        url << "/gists?per_page=100"
-        get_gist_pages(url, access_token)
-      else
-        raise Error, "Not authenticated. Use 'gist --login' to login or 'gist -l username' to view public gists."
-      end
-
+      url << "/gists?per_page=100"
     else
       url << "/users/#{user}/gists?per_page=100"
-      get_gist_pages(url)
     end
 
+    get_gist_pages(url, auth_token())
   end
 
   def read_gist(id, file_name=nil)


### PR DESCRIPTION
Always pass the authentication token when listing gists. It is needed even when listing public gists on GHE. Moreover, `bin/gist` enforces the presence of the auth token* . 

Here's the output without the auth token (bypassed check in `bin/gist`).

```
$ gist -l username
Traceback (most recent call last):
	7: from /usr/local/bin/gist:23:in `<main>'
	6: from /usr/local/bin/gist:23:in `load'
	5: from /var/lib/gems/2.5.0/gems/gist-5.1.0/bin/gist:167:in `<top (required)>'
	4: from /var/lib/gems/2.5.0/gems/gist-5.1.0/lib/gist.rb:213:in `list_all_gists'
	3: from /var/lib/gems/2.5.0/gems/gist-5.1.0/lib/gist.rb:269:in `get_gist_pages'
	2: from /var/lib/gems/2.5.0/gems/gist-5.1.0/lib/gist.rb:287:in `pretty_gist'
	1: from /usr/lib/ruby/2.5.0/json/common.rb:156:in `parse'
/usr/lib/ruby/2.5.0/json/common.rb:156:in `parse': 765: unexpected token at '' (JSON::ParserError)
```

This change was tested on GitHub and GitHub Enterprise.

* @ConradIrwin let me know if this if true and I will follow up with a cleanup PR that removes the other extraneous checks in other functions. I suspect this may not be true if you want to support anonymous listing of public gists (without login). But that currently doesn't appear to be supported after 09813a332d320c4c507d41a68f1f28948f4ccbc2 .