### PR TITLE
Use new Oauth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,26 @@ To read a gist and print it to STDOUT
 
 ## Login
 
-If you want to associate your gists with your GitHub account, you need to login
-with gist. It doesn't store your username and password, it just uses them to get
-an OAuth2 token (with the "gist" permission).
+Before you use `gist` for the first time you will need to log in. There are two supported login flows:
+
+1. The Github device-code Oauth flow. This is the default for authenticating to github.com, and can be enabled for Github Enterprise by creating an Oauth app, and exporting the environment variable `GIST_CLIENT_ID` with the client id of the Oauth app.
+2. The (deprecated) username and password token exchange flow. This is the default for GitHub Enterprise, and can be used to log into github.com by exporting the environment variable `GIST_USE_USERNAME_AND_PASSWORD`.
+
+### The device-code flow
+
+This flow allows you to obtain a token by logging into GitHub in the browser and typing a verification code. This is the preferred mechanism.
+
+    gist --login
+    Requesting login parameters...
+    Please sign in at https://github.com/login/device
+      and enter code: XXXX-XXXX
+    Success! https://github.com/settings/connections/applications/4f7ec0d4eab38e74384e
+
+The returned access_token is stored in `~/.gist` and used for all future gisting.  If you need to you can revoke access from  https://github.com/settings/connections/applications/4f7ec0d4eab38e74384e.
+
+### The username-password flow
+
+This flow asks for your GitHub username and password (and 2FA code), and exchanges them for a token with the "gist" permission (your username and password are not stored). This mechanism is deprecated by GitHub, but may still work with GitHub Enterprise.
 
     gist --login
     Obtaining OAuth2 access_token from GitHub.


### PR DESCRIPTION
The username/password exchange mechanism is (rightfully) deprecated, the
device flow is now in beta, and seems to be the perfect replacement.

This change includes a best-guess of how this might work with GitHub
Enterprise but I haven't tested that, so GitHub Enterprise will continue
to default to the deprecated flow.

Fixes #315