### PR TITLE
docs: Debian package renamed binary to `gist-paste`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ upload content to https://gist.github.com/.
 
     pkg install gist
 
+<200c>For Ubuntu/Debian
+
+    apt install gist
+
+Note: Debian renames the binary to `gist-paste` to avoid a name conflict.
 
 ## Command
 


### PR DESCRIPTION
It appears that the various installation methods currently documented are not more intuitive/convenient/? than using `apt`. Adding it to the instructions so we can document that it has been renamed by Debian to `gist-paste`. 

Hopefully, that will encourage people to use the preferred `gem` installation method.

Fixes #300