### PR TITLE
docs: remove unicode zero length characters and fix Markdown to man page conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,9 @@ setting it to the public URL will not work. Use `unset GITHUB_URL`
 
 If you cannot use passwords, as most Enterprise installations do, you can generate the token via the web interface
 and then simply save the string in the correct file. Avoid line breaks or you might see:
-```
-$ gist -l
-Error: Bad credentials
-```
+
+    $ gist -l
+    Error: Bad credentials
 
 # Library
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This token is stored in `~/.gist` and used for all future gisting. If you need t
 you can revoke it from https://github.com/settings/tokens, or just delete the
 file.
 
-#### Password-less login
+### Password-less login
 
 If you have a complicated authorization requirement you can manually create a
 token file by pasting a GitHub token with `gist` scope (and maybe the `user:email`

--- a/README.md
+++ b/README.md
@@ -8,84 +8,82 @@ upload content to https://gist.github.com/.
 
 ## Installation
 
-If you have ruby installed:
+* If you have ruby installed:
 
     gem install gist
 
-If you're using Bundler:
+* If you're using Bundler:
 
     source :rubygems
     gem 'gist'
 
-For OS X, gist lives in Homebrew
+* For OS X, `gist` lives in Homebrew
 
     brew install gist
 
-For FreeBSD, gist lives in ports
+* For FreeBSD, `gist` lives in ports
 
     pkg install gist
 
-For Ubuntu/Debian
+* For Ubuntu/Debian, `gist` has been renamed to `gist-paste` to avoid a name conflict
 
     apt install gist
 
-Note: Debian renames the binary to `gist-paste` to avoid a name conflict.
-
 ## Command
 
-To upload the contents of `a.rb` just:
+* To upload the contents of `a.rb` just:
 
     gist a.rb
 
-Upload multiple files:
+* Upload multiple files:
 
     gist a b c
     gist *.rb
 
-By default it reads from STDIN, and you can set a filename with `-f`.
+* By default it reads from STDIN, and you can set a filename with `-f`.
 
     gist -f test.rb <a.rb
 
-Alternatively, you can just paste from the clipboard:
+* Alternatively, you can just paste from the clipboard:
 
     gist -P
 
-Use `-p` to make the gist private:
+* Use `-p` to make the gist private:
 
     gist -p a.rb
 
-Use `-d` to add a description:
+* Use `-d` to add a description:
 
     gist -d "Random rbx bug" a.rb
 
-You can update existing gists with `-u`:
+* You can update existing gists with `-u`:
 
     gist -u GIST_ID FILE_NAME
     gist -u 42f2c239d2eb57299408 test.txt
 
-If you'd like to copy the resulting URL to your clipboard, use `-c`.
+* If you'd like to copy the resulting URL to your clipboard, use `-c`.
 
     gist -c <a.rb
 
-If you'd like to copy the resulting embeddable URL to your clipboard, use `-e`.
+* If you'd like to copy the resulting embeddable URL to your clipboard, use `-e`.
 
     gist -e <a.rb
 
-And you can just ask gist to open a browser window directly with `-o`.
+* And you can just ask gist to open a browser window directly with `-o`.
 
     gist -o <a.rb
 
-To list (public gists or all gists for authed user) gists for user
+* To list (public gists or all gists for authed user) gists for user
 
     gist -l : all gists for authed user
     gist -l defunkt : list defunkt's public gists
 
-To read a gist and print it to STDOUT
+* To read a gist and print it to STDOUT
 
     gist -r GIST_ID
     gist -r 374130
 
-See `gist --help` for more detail.
+* See `gist --help` for more detail.
 
 ## Login
 
@@ -119,7 +117,7 @@ This flow asks for your GitHub username and password (and 2FA code), and exchang
 
 This token is stored in `~/.gist` and used for all future gisting. If you need to
 you can revoke it from https://github.com/settings/tokens, or just delete the
-file. 
+file.
 
 #### Password-less login
 
@@ -165,7 +163,7 @@ Error: Bad credentials
 
 # Library
 
-You can also use Gist as a library from inside your ruby code:
+* You can also use Gist as a library from inside your ruby code:
 
     Gist.gist("Look.at(:my => 'awesome').code")
 
@@ -181,11 +179,11 @@ If you need more advanced features you can also pass:
 
 NOTE: The access_token must have the `gist` scope and may also require the `user:email` scope.
 
-If you want to upload multiple files in the same gist, you can:
+* If you want to upload multiple files in the same gist, you can:
 
     Gist.multi_gist("a.rb" => "Foo.bar", "a.py" => "Foo.bar")
 
-If you'd rather use gist's builtin access_token, then you can force the user
+* If you'd rather use gist's builtin access_token, then you can force the user
   to obtain one by calling:
 
     Gist.login!
@@ -195,12 +193,12 @@ in `~/.gist`, where it can later be read by `Gist.gist`
 
 ## Configuration
 
-If you'd like `-o` or `-c` to be the default when you use the gist executable, add an
+* If you'd like `-o` or `-c` to be the default when you use the gist executable, add an
 alias to your `~/.bashrc` (or equivalent). For example:
 
     alias gist='gist -c'
 
-If you'd prefer gist to open a different browser, then you can export the BROWSER
+* If you'd prefer gist to open a different browser, then you can export the BROWSER
 environment variable:
 
     export BROWSER=google-chrome

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ If you'd rather use gist's builtin access_token, then you can force the user
 
     Gist.login!
 
-‌This will take them through the process of obtaining an OAuth2 token, and storing it
+This will take them through the process of obtaining an OAuth2 token, and storing it
 in `~/.gist`, where it can later be read by `Gist.gist`
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ upload content to https://gist.github.com/.
 
 ## Installation
 
-‌If you have ruby installed:
+If you have ruby installed:
 
     gem install gist
 
-‌If you're using Bundler:
+If you're using Bundler:
 
     source :rubygems
     gem 'gist'
 
-‌For OS X, gist lives in Homebrew
+For OS X, gist lives in Homebrew
 
     brew install gist
 
-‌For FreeBSD, gist lives in ports
+For FreeBSD, gist lives in ports
 
     pkg install gist
 
-<200c>For Ubuntu/Debian
+For Ubuntu/Debian
 
     apt install gist
 
@@ -33,49 +33,49 @@ Note: Debian renames the binary to `gist-paste` to avoid a name conflict.
 
 ## Command
 
-‌To upload the contents of `a.rb` just:
+To upload the contents of `a.rb` just:
 
     gist a.rb
 
-‌Upload multiple files:
+Upload multiple files:
 
     gist a b c
     gist *.rb
 
-‌By default it reads from STDIN, and you can set a filename with `-f`.
+By default it reads from STDIN, and you can set a filename with `-f`.
 
     gist -f test.rb <a.rb
 
-‌Alternatively, you can just paste from the clipboard:
+Alternatively, you can just paste from the clipboard:
 
     gist -P
 
-‌Use `-p` to make the gist private:
+Use `-p` to make the gist private:
 
     gist -p a.rb
 
-‌Use `-d` to add a description:
+Use `-d` to add a description:
 
     gist -d "Random rbx bug" a.rb
 
-‌You can update existing gists with `-u`:
+You can update existing gists with `-u`:
 
     gist -u GIST_ID FILE_NAME
     gist -u 42f2c239d2eb57299408 test.txt
 
-‌If you'd like to copy the resulting URL to your clipboard, use `-c`.
+If you'd like to copy the resulting URL to your clipboard, use `-c`.
 
     gist -c <a.rb
 
-‌If you'd like to copy the resulting embeddable URL to your clipboard, use `-e`.
+If you'd like to copy the resulting embeddable URL to your clipboard, use `-e`.
 
     gist -e <a.rb
 
-‌And you can just ask gist to open a browser window directly with `-o`.
+And you can just ask gist to open a browser window directly with `-o`.
 
     gist -o <a.rb
 
-‌To list (public gists or all gists for authed user) gists for user
+To list (public gists or all gists for authed user) gists for user
 
     gist -l : all gists for authed user
     gist -l defunkt : list defunkt's public gists
@@ -85,7 +85,7 @@ To read a gist and print it to STDOUT
     gist -r GIST_ID
     gist -r 374130
 
-‌See `gist --help` for more detail.
+See `gist --help` for more detail.
 
 ## Login
 
@@ -104,7 +104,7 @@ This flow allows you to obtain a token by logging into GitHub in the browser and
       and enter code: XXXX-XXXX
     Success! https://github.com/settings/connections/applications/4f7ec0d4eab38e74384e
 
-The returned access_token is stored in `~/.gist` and used for all future gisting.  If you need to you can revoke access from  https://github.com/settings/connections/applications/4f7ec0d4eab38e74384e.
+The returned `access_token` is stored in `~/.gist` and used for all future gisting.  If you need to you can revoke access from  https://github.com/settings/connections/applications/4f7ec0d4eab38e74384e.
 
 ### The username-password flow
 
@@ -148,7 +148,7 @@ Once you've done this and restarted your terminal (or run `source ~/.bashrc`), g
 automatically use GitHub Enterprise instead of the public github.com
 
 Your token for GitHub Enterprise will be stored in `.gist.<protocol>.<server.name>[.<port>]` (e.g.
-`~/.gist.http.github.internal.example.com` for the GITHUB_URL example above) instead of `~/.gist`.
+`~/.gist.http.github.internal.example.com` for the `GITHUB_URL` example above) instead of `~/.gist`.
 
 If you have multiple servers or use Enterprise and public GitHub often, you can work around this by creating scripts
 that set the env var and then run `gist`. Keep in mind that to use the public GitHub you must unset the env var. Just
@@ -165,7 +165,7 @@ Error: Bad credentials
 
 # Library
 
-‌You can also use Gist as a library from inside your ruby code:
+You can also use Gist as a library from inside your ruby code:
 
     Gist.gist("Look.at(:my => 'awesome').code")
 
@@ -181,11 +181,11 @@ If you need more advanced features you can also pass:
 
 NOTE: The access_token must have the `gist` scope and may also require the `user:email` scope.
 
-‌If you want to upload multiple files in the same gist, you can:
+If you want to upload multiple files in the same gist, you can:
 
     Gist.multi_gist("a.rb" => "Foo.bar", "a.py" => "Foo.bar")
 
-‌If you'd rather use gist's builtin access_token, then you can force the user
+If you'd rather use gist's builtin access_token, then you can force the user
   to obtain one by calling:
 
     Gist.login!
@@ -195,12 +195,12 @@ in `~/.gist`, where it can later be read by `Gist.gist`
 
 ## Configuration
 
-‌If you'd like `-o` or `-c` to be the default when you use the gist executable, add an
+If you'd like `-o` or `-c` to be the default when you use the gist executable, add an
 alias to your `~/.bashrc` (or equivalent). For example:
 
     alias gist='gist -c'
 
-‌If you'd prefer gist to open a different browser, then you can export the BROWSER
+If you'd prefer gist to open a different browser, then you can export the BROWSER
 environment variable:
 
     export BROWSER=google-chrome

--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,7 @@ end
 
 task :man do
   mkdir_p "build"
-  File.write "README.md.ron", File.read("README.md").gsub("\u200c", "* ")
-  sh 'ronn --roff --manual="Gist manual" README.md.ron'
-  rm 'README.md.ron'
+  sh 'ronn --roff --manual="Gist manual" README.md'
   mv 'README.1', 'build/gist.1'
 end
 


### PR DESCRIPTION
Fix the typo from #325 and remove Unicode zero width characters from Markdown. Also format some vars with backticks.

Rendering of the README.md on github.com has not changed without the Unicode characters.