### PR TITLE
Fix SSL Verification

### DIFF
--- a/build/gist
+++ b/build/gist
@@ -1273,7 +1273,7 @@ module ::Kernel
     nil
   end
 
-  # Ouputs _objs_ to STDOUT as JSON strings in a pretty format, with
+  # Outputs _objs_ to STDOUT as JSON strings in a pretty format, with
   # indentation and over many lines.
   def jj(*objs)
     objs.each do |obj|
@@ -1409,7 +1409,7 @@ module Gist
   # @option options [Boolean] :skip_empty (false) Skip gisting empty files.
   # @option options [Symbol] :output (:all) The type of return value you'd like:
   #   :html_url gives a String containing the url to the gist in a browser
-  #   :short_url gives a String contianing a  git.io url that redirects to html_url
+  #   :short_url gives a String containing a  git.io url that redirects to html_url
   #   :javascript gives a String containing a script tag suitable for embedding the gist
   #   :all gives a Hash containing the parsed json response from the server
   #
@@ -1518,10 +1518,13 @@ module Gist
     get_gist_pages(url, auth_token())
   end
 
-  def read_gist(id, file_name=nil)
+  def read_gist(id, file_name=nil, options={})
     url = "#{base_path}/gists/#{id}"
 
-    access_token = auth_token()
+    access_token = (options[:access_token] || auth_token())
+    if access_token.to_s != ''
+      url << "?access_token=" << CGI.escape(access_token)
+    end
 
     request = Net::HTTP::Get.new(url)
     request['Authorization'] = "token #{access_token}" if access_token.to_s != ''
@@ -1538,7 +1541,7 @@ module Gist
         file = files.values.first
       end
 
-      puts file["content"]
+      file["content"]
     else
       raise Error, "Gist with id of #{id} does not exist."
     end
@@ -1770,7 +1773,7 @@ module Gist
                  end
     if uri.scheme == "https"
       connection.use_ssl = true
-      connection.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
     connection.open_timeout = 10
     connection.read_timeout = 10
@@ -2118,7 +2121,8 @@ begin
 
   if options.key? :read
     file_name = ARGV.first
-    Gist.read_gist(options[:read], file_name)
+    output = Gist.read_gist(options[:read], file_name)
+    puts output if output
     exit
   end
 

--- a/build/gist
+++ b/build/gist
@@ -1522,9 +1522,6 @@ module Gist
     url = "#{base_path}/gists/#{id}"
 
     access_token = (options[:access_token] || auth_token())
-    if access_token.to_s != ''
-      url << "?access_token=" << CGI.escape(access_token)
-    end
 
     request = Net::HTTP::Get.new(url)
     request['Authorization'] = "token #{access_token}" if access_token.to_s != ''

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -216,9 +216,6 @@ module Gist
     url = "#{base_path}/gists/#{id}"
 
     access_token = (options[:access_token] || auth_token())
-    if access_token.to_s != ''
-      url << "?access_token=" << CGI.escape(access_token)
-    end
 
     request = Net::HTTP::Get.new(url)
     request['Authorization'] = "token #{access_token}" if access_token.to_s != ''

--- a/lib/gist.rb
+++ b/lib/gist.rb
@@ -467,7 +467,7 @@ module Gist
                  end
     if uri.scheme == "https"
       connection.use_ssl = true
-      connection.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
     end
     connection.open_timeout = 10
     connection.read_timeout = 10

--- a/vendor/json.rb
+++ b/vendor/json.rb
@@ -44,7 +44,7 @@ module JSON
           /(?=\*/)      # single slash before this comment's end
          )*
            \*/               # the End of this comment
-           |[ \t\r\n]+       # whitespaces: space, horicontal tab, lf, cr
+           |[ \t\r\n]+       # whitespaces: space, horizontal tab, lf, cr
         )+
       )mx
 
@@ -64,7 +64,7 @@ module JSON
       #   (keys) in a JSON object. Otherwise strings are returned, which is also
       #   the default.
       # * *create_additions*: If set to false, the Parser doesn't create
-      #   additions even if a matchin class and create_id was found. This option
+      #   additions even if a matching class and create_id was found. This option
       #   defaults to true.
       # * *object_class*: Defaults to Hash
       # * *array_class*: Defaults to Array


### PR DESCRIPTION
- **Verify TLS certificates when talking to GitHub**
- **Don't put auth tokens in the URL**

Fixes #373

Note, the code was original written like this because Ruby had a bad story
around certificate management. I believe this was fixed cira 2016; so we should
be ok to rely on it now.

